### PR TITLE
Add interactive dashboard and API for WeatherFlow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ ENV/
 .idea/
 .vscode/
 *.swp
+
+# Frontend artifacts
+frontend/node_modules/
+frontend/dist/

--- a/README.md
+++ b/README.md
@@ -111,6 +111,44 @@ python examples/weather_prediction.py --variables z t --pressure-levels 500 \
     --use-attention --physics-informed --save-model --save-results
 ```
 
+## Interactive Web Dashboard
+
+WeatherFlow now ships with a lightweight FastAPI service and React-based
+dashboard that let you explore the library without writing code. The dashboard
+walks you through dataset synthesis, model configuration, training, and flow
+visualisation using the core `WeatherFlowMatch` and `WeatherFlowODE`
+components.
+
+### 1. Start the API service
+
+```bash
+uvicorn weatherflow.server.app:app --reload --port 8000
+```
+
+The server exposes `/api/options` for configuration metadata and
+`/api/experiments` to launch a synthetic training run that exercises the
+weather flow models and ODE solver.
+
+### 2. Install and run the React app
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Open the printed URL (typically http://localhost:5173) in your browser to
+interact with the dashboard. Use the panels on the left to configure data,
+model, and training parameters, then run an experiment to inspect loss curves,
+channel statistics, and generated trajectories on the right-hand side.
+
+To produce a production build and run the component tests:
+
+```bash
+npm run build
+npm test
+```
+
 ## Key Components
 
 ### Data Loading

--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -1,0 +1,29 @@
+module.exports = {
+  env: {
+    browser: true,
+    es2021: true
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'plugin:react-hooks/recommended'
+  ],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true
+    },
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  plugins: ['react', '@typescript-eslint', 'jsx-a11y'],
+  rules: {
+    'react/react-in-jsx-scope': 'off',
+    'react/prop-types': 'off'
+  },
+  settings: {
+    react: {
+      version: 'detect'
+    }
+  }
+};

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WeatherFlow Studio</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "weatherflow-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "test": "vitest run",
+    "lint": "eslint src --ext ts,tsx --max-warnings=0"
+  },
+  "dependencies": {
+    "axios": "^1.6.8",
+    "plotly.js-dist-min": "^2.27.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-plotly.js": "^2.5.1"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.1.4",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/node": "^20.12.7",
+    "@types/plotly.js": "^2.12.26",
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0",
+    "@vitejs/plugin-react": "^4.2.1",
+    "eslint": "^8.57.0",
+    "eslint-plugin-react": "^7.34.1",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-jsx-a11y": "^6.8.0",
+    "jsdom": "^24.0.0",
+    "typescript": "^5.4.3",
+    "vite": "^5.2.0",
+    "vitest": "^1.5.0"
+  }
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,405 @@
+.app-shell {
+  max-width: 1440px;
+  margin: 0 auto;
+  padding: 1.5rem 2rem 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  background-color: rgba(255, 255, 255, 0.92);
+  padding: 1.25rem 1.75rem;
+  border-radius: 20px;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+}
+
+.app-header h1 {
+  margin: 0 0 0.35rem;
+  font-size: 2rem;
+  color: #0f172a;
+}
+
+.subtitle {
+  margin: 0;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.app-main {
+  display: grid;
+  grid-template-columns: minmax(320px, 380px) 1fr;
+  gap: 1.5rem;
+}
+
+.config-column,
+.results-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.config-column {
+  position: sticky;
+  top: 1.5rem;
+  align-self: start;
+}
+
+.section-card {
+  background-color: rgba(255, 255, 255, 0.92);
+  border-radius: 18px;
+  padding: 1.25rem 1.5rem;
+  box-shadow: 0 18px 30px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.section-card h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #0f172a;
+}
+
+.section-card p {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.9rem;
+}
+
+.form-grid {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.form-grid label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.85rem;
+  color: #1f2937;
+  gap: 0.35rem;
+}
+
+.form-grid input,
+.form-grid select {
+  border: 1px solid #d4d4d8;
+  border-radius: 10px;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.95rem;
+  background: #fff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-grid input:focus,
+.form-grid select:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
+}
+
+.checkbox-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.input-label {
+  display: block;
+  font-weight: 600;
+  color: #1e293b;
+  margin-bottom: 0.35rem;
+}
+
+.checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: #1f2937;
+}
+
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.primary-button {
+  padding: 0.65rem 1.5rem;
+  border-radius: 12px;
+  border: none;
+  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 16px 24px rgba(37, 99, 235, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.primary-button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 20px 30px rgba(37, 99, 235, 0.25);
+}
+
+.ghost-button {
+  padding: 0.55rem 1.1rem;
+  border-radius: 10px;
+  border: 1px solid #94a3b8;
+  background: transparent;
+  color: #1e293b;
+  cursor: pointer;
+  font-weight: 500;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.ghost-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.ghost-button:not(:disabled):hover {
+  color: #1d4ed8;
+  border-color: #1d4ed8;
+}
+
+.results-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.summary-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.summary-header p {
+  margin: 0.35rem 0 0;
+  color: #64748b;
+}
+
+.summary-duration {
+  background: rgba(59, 130, 246, 0.1);
+  color: #1d4ed8;
+  padding: 0.55rem 0.9rem;
+  border-radius: 12px;
+  font-weight: 600;
+  align-self: center;
+}
+
+.summary-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.summary-grid h3 {
+  margin: 0 0 0.35rem;
+  font-size: 1rem;
+  color: #0f172a;
+}
+
+.summary-grid ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+.summary-grid li strong {
+  color: #0f172a;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  text-align: left;
+  padding: 0.55rem 0.75rem;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+th {
+  color: #0f172a;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+tbody tr:hover {
+  background-color: #f8fafc;
+}
+
+.error-banner {
+  background: #fee2e2;
+  border: 1px solid #fecaca;
+  color: #991b1b;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.error-banner strong {
+  font-size: 0.95rem;
+}
+
+.loading-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: rgba(15, 23, 42, 0.45);
+  color: #ffffff;
+  gap: 1rem;
+  z-index: 1000;
+}
+
+.loading-overlay p {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 500;
+}
+
+.loading-spinner {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: 4px solid rgba(255, 255, 255, 0.4);
+  border-top-color: #ffffff;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.prediction-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.prediction-header p {
+  margin: 0.25rem 0 0;
+  color: #64748b;
+}
+
+.prediction-stats {
+  display: flex;
+  gap: 1rem;
+  background: rgba(37, 99, 235, 0.08);
+  padding: 0.5rem 0.85rem;
+  border-radius: 12px;
+}
+
+.prediction-stats div {
+  display: flex;
+  flex-direction: column;
+  text-align: right;
+}
+
+.prediction-stats span {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #1d4ed8;
+}
+
+.prediction-stats strong {
+  font-size: 1rem;
+  color: #1e293b;
+}
+
+.prediction-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin: 1rem 0;
+}
+
+.prediction-controls label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  color: #1f2937;
+  font-size: 0.9rem;
+}
+
+.slider-label {
+  flex: 1;
+  min-width: 200px;
+}
+
+.slider-label input[type='range'] {
+  width: 100%;
+}
+
+.slider-value {
+  font-size: 0.85rem;
+  color: #1e293b;
+  font-weight: 600;
+}
+
+.heatmap-grid {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.comparison-panels {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.comparison-panels h3 {
+  margin: 0 0 0.35rem;
+  color: #0f172a;
+}
+
+@media (max-width: 1100px) {
+  .app-main {
+    grid-template-columns: 1fr;
+  }
+
+  .config-column {
+    position: relative;
+    top: 0;
+  }
+}

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,0 +1,154 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import App from './App';
+import { ExperimentResult, ServerOptions } from './api/types';
+import { fetchOptions, runExperiment } from './api/client';
+
+vi.mock('./api/client', () => ({
+  fetchOptions: vi.fn(),
+  runExperiment: vi.fn()
+}));
+
+const mockOptions: ServerOptions = {
+  variables: ['t', 'z', 'u', 'v'],
+  pressureLevels: [500, 700],
+  gridSizes: [
+    { lat: 16, lon: 32 },
+    { lat: 32, lon: 64 }
+  ],
+  solverMethods: ['dopri5', 'rk4'],
+  lossTypes: ['mse', 'huber'],
+  maxEpochs: 5
+};
+
+const mockResult: ExperimentResult = {
+  experimentId: 'test-123',
+  config: {
+    dataset: {
+      variables: ['t'],
+      pressureLevels: [500],
+      gridSize: { lat: 16, lon: 32 },
+      trainSamples: 16,
+      valSamples: 8
+    },
+    model: {
+      hiddenDim: 64,
+      nLayers: 2,
+      useAttention: true,
+      physicsInformed: true
+    },
+    training: {
+      epochs: 1,
+      batchSize: 4,
+      learningRate: 0.001,
+      solverMethod: 'dopri5',
+      timeSteps: 3,
+      lossType: 'mse',
+      seed: 42,
+      dynamicsScale: 0.1
+    }
+  },
+  channelNames: ['t@500'],
+  metrics: {
+    train: [
+      {
+        epoch: 1,
+        loss: 0.5,
+        flowLoss: 0.4,
+        divergenceLoss: 0.05,
+        energyDiff: 0.1
+      }
+    ]
+  },
+  validation: {
+    metrics: [
+      {
+        epoch: 1,
+        valLoss: 0.6,
+        valFlowLoss: 0.5,
+        valDivergenceLoss: 0.05,
+        valEnergyDiff: 0.09
+      }
+    ]
+  },
+  datasetSummary: {
+    channelStats: [
+      {
+        name: 't@500',
+        mean: 0.1,
+        std: 1.2,
+        min: -2.3,
+        max: 2.5
+      }
+    ],
+    sampleShape: [1, 16, 32]
+  },
+  prediction: {
+    times: [0, 0.5, 1],
+    channels: [
+      {
+        name: 't@500',
+        initial: [
+          [0, 1],
+          [1, 0]
+        ],
+        target: [
+          [1, 2],
+          [2, 1]
+        ],
+        trajectory: [
+          { time: 0, data: [[0, 0.5], [0.5, 0]] },
+          { time: 0.5, data: [[0.5, 1.5], [1.2, 0.8]] },
+          { time: 1, data: [[1, 2], [2, 1]] }
+        ],
+        rmse: 0.4,
+        mae: 0.3,
+        baselineRmse: 0.8
+      }
+    ]
+  },
+  execution: {
+    durationSeconds: 0.42
+  }
+};
+
+const mockedFetchOptions = vi.mocked(fetchOptions);
+const mockedRunExperiment = vi.mocked(runExperiment);
+
+describe('App', () => {
+  beforeEach(() => {
+    mockedFetchOptions.mockResolvedValue(mockOptions);
+    mockedRunExperiment.mockResolvedValue(mockResult);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders configuration panels after loading options', async () => {
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Dataset configuration/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByLabelText(/Training samples/i)).toBeInTheDocument();
+    expect(screen.getByText(/Model architecture/i)).toBeInTheDocument();
+  });
+
+  it('runs an experiment and shows summary', async () => {
+    render(<App />);
+    const user = userEvent.setup();
+
+    const runButton = await screen.findByRole('button', { name: /Run experiment/i });
+    await user.click(runButton);
+
+    await waitFor(() => {
+      expect(mockedRunExperiment).toHaveBeenCalledTimes(1);
+    });
+
+    expect(await screen.findByText(/Experiment summary/i)).toBeInTheDocument();
+    expect(screen.getByText(/Runtime/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useMemo, useState } from 'react';
+import './App.css';
+import {
+  DatasetConfig,
+  ExperimentConfig,
+  ExperimentResult,
+  ModelConfig,
+  ServerOptions,
+  TrainingConfig
+} from './api/types';
+import { fetchOptions, runExperiment } from './api/client';
+import DatasetConfigurator from './components/DatasetConfigurator';
+import ModelConfigurator from './components/ModelConfigurator';
+import TrainingConfigurator from './components/TrainingConfigurator';
+import ResultsPanel from './components/ResultsPanel';
+import LoadingOverlay from './components/LoadingOverlay';
+import ErrorNotice from './components/ErrorNotice';
+
+const defaultModelConfig: ModelConfig = {
+  hiddenDim: 96,
+  nLayers: 3,
+  useAttention: true,
+  physicsInformed: true
+};
+
+const createDefaultDatasetConfig = (options: ServerOptions): DatasetConfig => ({
+  variables: options.variables.slice(0, 2),
+  pressureLevels: [options.pressureLevels[0]],
+  gridSize: options.gridSizes[0] ?? { lat: 16, lon: 32 },
+  trainSamples: 48,
+  valSamples: 16
+});
+
+const createDefaultTrainingConfig = (options: ServerOptions): TrainingConfig => ({
+  epochs: Math.min(2, options.maxEpochs),
+  batchSize: 8,
+  learningRate: 5e-4,
+  solverMethod: options.solverMethods[0] ?? 'dopri5',
+  timeSteps: 5,
+  lossType: options.lossTypes[0] ?? 'mse',
+  seed: 42,
+  dynamicsScale: 0.15
+});
+
+function App(): JSX.Element {
+  const [options, setOptions] = useState<ServerOptions | null>(null);
+  const [datasetConfig, setDatasetConfig] = useState<DatasetConfig | null>(null);
+  const [modelConfig, setModelConfig] = useState<ModelConfig>(defaultModelConfig);
+  const [trainingConfig, setTrainingConfig] = useState<TrainingConfig | null>(null);
+  const [result, setResult] = useState<ExperimentResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchOptions()
+      .then((data) => {
+        setOptions(data);
+        setDatasetConfig((current) => current ?? createDefaultDatasetConfig(data));
+        setTrainingConfig((current) => current ?? createDefaultTrainingConfig(data));
+      })
+      .catch((err: Error) => {
+        setError(`Failed to load server options: ${err.message}`);
+      });
+  }, []);
+
+  const canRunExperiment = useMemo(
+    () => Boolean(options && datasetConfig && trainingConfig && datasetConfig.variables.length > 0),
+    [options, datasetConfig, trainingConfig]
+  );
+
+  const handleRunExperiment = async () => {
+    if (!options || !datasetConfig || !trainingConfig) {
+      return;
+    }
+
+    const config: ExperimentConfig = {
+      dataset: datasetConfig,
+      model: modelConfig,
+      training: trainingConfig
+    };
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await runExperiment(config);
+      setResult(response);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      setError(`Experiment failed: ${message}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleReset = () => {
+    if (!options) {
+      return;
+    }
+    setDatasetConfig(createDefaultDatasetConfig(options));
+    setModelConfig(defaultModelConfig);
+    setTrainingConfig(createDefaultTrainingConfig(options));
+    setResult(null);
+  };
+
+  return (
+    <div className="app-shell">
+      <header className="app-header">
+        <div>
+          <h1>WeatherFlow Studio</h1>
+          <p className="subtitle">Configure, train, and evaluate WeatherFlow models with an interactive dashboard.</p>
+        </div>
+        <div className="header-actions">
+          <button type="button" onClick={handleReset} disabled={!options} className="ghost-button">
+            Reset configuration
+          </button>
+        </div>
+      </header>
+
+      {error && <ErrorNotice message={error} />}
+
+      <main className="app-main">
+        <section className="config-column">
+          <DatasetConfigurator
+            options={options}
+            value={datasetConfig}
+            onChange={setDatasetConfig}
+          />
+          <ModelConfigurator value={modelConfig} onChange={setModelConfig} />
+          <TrainingConfigurator
+            options={options}
+            value={trainingConfig}
+            onChange={setTrainingConfig}
+          />
+          <div className="actions">
+            <button
+              type="button"
+              className="primary-button"
+              onClick={handleRunExperiment}
+              disabled={!canRunExperiment || loading}
+            >
+              {loading ? 'Running...' : 'Run experiment'}
+            </button>
+          </div>
+        </section>
+        <section className="results-column">
+          <ResultsPanel
+            result={result}
+            loading={loading}
+            hasConfig={Boolean(canRunExperiment)}
+          />
+        </section>
+      </main>
+
+      {loading && <LoadingOverlay message="Running WeatherFlow experiment..." />}
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,21 @@
+import axios from 'axios';
+import { ExperimentConfig, ExperimentResult, ServerOptions } from './types';
+
+const baseURL = import.meta.env.VITE_API_URL ?? 'http://localhost:8000';
+
+const client = axios.create({
+  baseURL,
+  headers: {
+    'Content-Type': 'application/json'
+  }
+});
+
+export async function fetchOptions(): Promise<ServerOptions> {
+  const response = await client.get<ServerOptions>('/api/options');
+  return response.data;
+}
+
+export async function runExperiment(config: ExperimentConfig): Promise<ExperimentResult> {
+  const response = await client.post<ExperimentResult>('/api/experiments', config);
+  return response.data;
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1,0 +1,102 @@
+export interface GridSize {
+  lat: number;
+  lon: number;
+}
+
+export interface DatasetConfig {
+  variables: string[];
+  pressureLevels: number[];
+  gridSize: GridSize;
+  trainSamples: number;
+  valSamples: number;
+}
+
+export interface ModelConfig {
+  hiddenDim: number;
+  nLayers: number;
+  useAttention: boolean;
+  physicsInformed: boolean;
+}
+
+export type LossType = 'mse' | 'huber' | 'smooth_l1';
+
+export interface TrainingConfig {
+  epochs: number;
+  batchSize: number;
+  learningRate: number;
+  solverMethod: string;
+  timeSteps: number;
+  lossType: LossType;
+  seed: number;
+  dynamicsScale: number;
+}
+
+export interface ExperimentConfig {
+  dataset: DatasetConfig;
+  model: ModelConfig;
+  training: TrainingConfig;
+}
+
+export interface ServerOptions {
+  variables: string[];
+  pressureLevels: number[];
+  gridSizes: GridSize[];
+  solverMethods: string[];
+  lossTypes: LossType[];
+  maxEpochs: number;
+}
+
+export interface ChannelStats {
+  name: string;
+  mean: number;
+  std: number;
+  min: number;
+  max: number;
+}
+
+export interface MetricEntry {
+  epoch: number;
+  loss: number;
+  flowLoss: number;
+  divergenceLoss: number;
+  energyDiff: number;
+}
+
+export interface ValidationMetricEntry {
+  epoch: number;
+  valLoss: number;
+  valFlowLoss: number;
+  valDivergenceLoss: number;
+  valEnergyDiff: number;
+}
+
+export interface TrajectoryStep {
+  time: number;
+  data: number[][];
+}
+
+export interface ChannelTrajectory {
+  name: string;
+  initial: number[][];
+  target: number[][];
+  trajectory: TrajectoryStep[];
+  rmse: number;
+  mae: number;
+  baselineRmse: number;
+}
+
+export interface PredictionResult {
+  times: number[];
+  channels: ChannelTrajectory[];
+}
+
+export interface ExperimentResult {
+  experimentId: string;
+  config: ExperimentConfig;
+  channelNames: string[];
+  metrics: { train: MetricEntry[] };
+  validation: { metrics: ValidationMetricEntry[] };
+  datasetSummary: { channelStats: ChannelStats[]; sampleShape: number[] };
+  prediction: PredictionResult;
+  execution: { durationSeconds: number };
+}

--- a/frontend/src/components/DatasetConfigurator.tsx
+++ b/frontend/src/components/DatasetConfigurator.tsx
@@ -1,0 +1,139 @@
+import { ChangeEvent } from 'react';
+import { DatasetConfig, GridSize, ServerOptions } from '../api/types';
+
+interface Props {
+  options: ServerOptions | null;
+  value: DatasetConfig | null;
+  onChange: (config: DatasetConfig) => void;
+}
+
+function DatasetConfigurator({ options, value, onChange }: Props): JSX.Element {
+  const handleVariableToggle = (variable: string) => {
+    if (!value) {
+      return;
+    }
+    const exists = value.variables.includes(variable);
+    const variables = exists
+      ? value.variables.filter((item) => item !== variable)
+      : [...value.variables, variable];
+    onChange({ ...value, variables });
+  };
+
+  const handlePressureToggle = (level: number) => {
+    if (!value) {
+      return;
+    }
+    const exists = value.pressureLevels.includes(level);
+    const pressureLevels = exists
+      ? value.pressureLevels.filter((item) => item !== level)
+      : [...value.pressureLevels, level];
+    onChange({ ...value, pressureLevels });
+  };
+
+  const handleGridChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    if (!value) {
+      return;
+    }
+    const [lat, lon] = event.target.value.split('x').map(Number) as [number, number];
+    const gridSize: GridSize = { lat, lon };
+    onChange({ ...value, gridSize });
+  };
+
+  const handleNumericChange = (event: ChangeEvent<HTMLInputElement>) => {
+    if (!value) {
+      return;
+    }
+    const { name, value: raw } = event.target;
+    const numeric = Number(raw);
+    onChange({ ...value, [name]: Number.isNaN(numeric) ? 0 : numeric });
+  };
+
+  if (!options || !value) {
+    return (
+      <section className="section-card">
+        <h2>Dataset configuration</h2>
+        <p>Waiting for server options…</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="section-card">
+      <div>
+        <h2>Dataset configuration</h2>
+        <p>Choose the atmospheric variables and grid used to synthesise training data.</p>
+      </div>
+
+      <div className="form-grid">
+        <div>
+          <span className="input-label">Variables</span>
+          <div className="checkbox-group">
+            {options.variables.map((variable) => (
+              <label key={variable} className="checkbox-row">
+                <input
+                  type="checkbox"
+                  checked={value.variables.includes(variable)}
+                  onChange={() => handleVariableToggle(variable)}
+                />
+                {variable.toUpperCase()}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <span className="input-label">Pressure levels (hPa)</span>
+          <div className="checkbox-group">
+            {options.pressureLevels.map((level) => (
+              <label key={level} className="checkbox-row">
+                <input
+                  type="checkbox"
+                  checked={value.pressureLevels.includes(level)}
+                  onChange={() => handlePressureToggle(level)}
+                />
+                {level}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <label>
+          Grid resolution
+          <select value={`${value.gridSize.lat}x${value.gridSize.lon}`} onChange={handleGridChange}>
+            {options.gridSizes.map((grid) => (
+              <option key={`${grid.lat}x${grid.lon}`} value={`${grid.lat}x${grid.lon}`}>
+                {grid.lat} x {grid.lon}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label>
+          Training samples
+          <input
+            type="number"
+            min={4}
+            max={256}
+            name="trainSamples"
+            value={value.trainSamples}
+            onChange={handleNumericChange}
+          />
+        </label>
+
+        <label>
+          Validation samples
+          <input
+            type="number"
+            min={4}
+            max={128}
+            name="valSamples"
+            value={value.valSamples}
+            onChange={handleNumericChange}
+          />
+        </label>
+      </div>
+    </section>
+  );
+}
+
+export default DatasetConfigurator;

--- a/frontend/src/components/DatasetStats.tsx
+++ b/frontend/src/components/DatasetStats.tsx
@@ -1,0 +1,39 @@
+import { ChannelStats } from '../api/types';
+
+interface Props {
+  stats: ChannelStats[];
+}
+
+function DatasetStats({ stats }: Props): JSX.Element {
+  return (
+    <section className="section-card">
+      <h2>Dataset statistics</h2>
+      <div className="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>Channel</th>
+              <th>Mean</th>
+              <th>Std</th>
+              <th>Min</th>
+              <th>Max</th>
+            </tr>
+          </thead>
+          <tbody>
+            {stats.map((stat) => (
+              <tr key={stat.name}>
+                <td>{stat.name.toUpperCase()}</td>
+                <td>{stat.mean.toFixed(3)}</td>
+                <td>{stat.std.toFixed(3)}</td>
+                <td>{stat.min.toFixed(3)}</td>
+                <td>{stat.max.toFixed(3)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+export default DatasetStats;

--- a/frontend/src/components/ErrorNotice.tsx
+++ b/frontend/src/components/ErrorNotice.tsx
@@ -1,0 +1,14 @@
+interface Props {
+  message: string;
+}
+
+function ErrorNotice({ message }: Props): JSX.Element {
+  return (
+    <div className="error-banner" role="alert">
+      <strong>Something went wrong:</strong>
+      <span>{message}</span>
+    </div>
+  );
+}
+
+export default ErrorNotice;

--- a/frontend/src/components/LoadingOverlay.tsx
+++ b/frontend/src/components/LoadingOverlay.tsx
@@ -1,0 +1,14 @@
+interface Props {
+  message?: string;
+}
+
+function LoadingOverlay({ message = 'Loading…' }: Props): JSX.Element {
+  return (
+    <div className="loading-overlay">
+      <div className="loading-spinner" aria-hidden="true" />
+      <p>{message}</p>
+    </div>
+  );
+}
+
+export default LoadingOverlay;

--- a/frontend/src/components/LossChart.tsx
+++ b/frontend/src/components/LossChart.tsx
@@ -1,0 +1,66 @@
+import Plot from 'react-plotly.js';
+import { MetricEntry, ValidationMetricEntry } from '../api/types';
+
+interface Props {
+  train: MetricEntry[];
+  validation: ValidationMetricEntry[];
+}
+
+function LossChart({ train, validation }: Props): JSX.Element {
+  const trainEpochs = train.map((metric) => metric.epoch);
+  const valEpochs = validation.map((metric) => metric.epoch);
+
+  return (
+    <section className="section-card">
+      <h2>Training history</h2>
+      <Plot
+        data={[
+          {
+            x: trainEpochs,
+            y: train.map((metric) => metric.loss),
+            type: 'scatter',
+            mode: 'lines+markers',
+            name: 'Train total'
+          },
+          {
+            x: trainEpochs,
+            y: train.map((metric) => metric.flowLoss),
+            type: 'scatter',
+            mode: 'lines+markers',
+            name: 'Train flow',
+            line: { dash: 'dot' }
+          },
+          {
+            x: valEpochs,
+            y: validation.map((metric) => metric.valLoss),
+            type: 'scatter',
+            mode: 'lines+markers',
+            name: 'Validation total'
+          },
+          {
+            x: valEpochs,
+            y: validation.map((metric) => metric.valFlowLoss),
+            type: 'scatter',
+            mode: 'lines+markers',
+            name: 'Validation flow',
+            line: { dash: 'dot' }
+          }
+        ]}
+        layout={{
+          autosize: true,
+          margin: { t: 30, r: 20, b: 40, l: 50 },
+          paper_bgcolor: 'rgba(0,0,0,0)',
+          plot_bgcolor: 'rgba(0,0,0,0)',
+          height: 320,
+          legend: { orientation: 'h', y: -0.2 },
+          xaxis: { title: 'Epoch' },
+          yaxis: { title: 'Loss', rangemode: 'tozero' }
+        }}
+        style={{ width: '100%', height: '100%' }}
+        config={{ displayModeBar: false, responsive: true }}
+      />
+    </section>
+  );
+}
+
+export default LossChart;

--- a/frontend/src/components/ModelConfigurator.tsx
+++ b/frontend/src/components/ModelConfigurator.tsx
@@ -1,0 +1,67 @@
+import { ChangeEvent } from 'react';
+import { ModelConfig } from '../api/types';
+
+interface Props {
+  value: ModelConfig;
+  onChange: (config: ModelConfig) => void;
+}
+
+function ModelConfigurator({ value, onChange }: Props): JSX.Element {
+  const handleNumberChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { name, value: raw } = event.target;
+    onChange({ ...value, [name]: Number(raw) });
+  };
+
+  const handleToggle = (event: ChangeEvent<HTMLInputElement>) => {
+    const { name, checked } = event.target;
+    onChange({ ...value, [name]: checked });
+  };
+
+  return (
+    <section className="section-card">
+      <div>
+        <h2>Model architecture</h2>
+        <p>Configure the WeatherFlowMatch backbone used for the experiment.</p>
+      </div>
+      <div className="form-grid">
+        <label>
+          Hidden dimension
+          <input
+            type="number"
+            min={32}
+            max={512}
+            name="hiddenDim"
+            value={value.hiddenDim}
+            onChange={handleNumberChange}
+          />
+        </label>
+        <label>
+          Layers
+          <input
+            type="number"
+            min={1}
+            max={8}
+            name="nLayers"
+            value={value.nLayers}
+            onChange={handleNumberChange}
+          />
+        </label>
+        <label className="checkbox-row">
+          <input type="checkbox" name="useAttention" checked={value.useAttention} onChange={handleToggle} />
+          Use multi-head attention
+        </label>
+        <label className="checkbox-row">
+          <input
+            type="checkbox"
+            name="physicsInformed"
+            checked={value.physicsInformed}
+            onChange={handleToggle}
+          />
+          Apply physics constraints
+        </label>
+      </div>
+    </section>
+  );
+}
+
+export default ModelConfigurator;

--- a/frontend/src/components/PredictionViewer.tsx
+++ b/frontend/src/components/PredictionViewer.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useMemo, useState } from 'react';
+import Plot from 'react-plotly.js';
+import { PredictionResult } from '../api/types';
+
+interface Props {
+  prediction: PredictionResult;
+}
+
+function PredictionViewer({ prediction }: Props): JSX.Element {
+  const [channelIndex, setChannelIndex] = useState(0);
+  const [stepIndex, setStepIndex] = useState(0);
+
+  const channels = prediction.channels;
+  if (channels.length === 0) {
+    return (
+      <section className="section-card">
+        <h2>Prediction explorer</h2>
+        <p>No prediction data available.</p>
+      </section>
+    );
+  }
+  const selectedChannel = channels[channelIndex];
+
+  useEffect(() => {
+    setStepIndex((index) => Math.min(index, selectedChannel.trajectory.length - 1));
+  }, [channelIndex, selectedChannel]);
+
+  const sliderMax = Math.max(selectedChannel.trajectory.length - 1, 0);
+  const safeStepIndex = Math.min(stepIndex, sliderMax);
+
+  const activeStep = useMemo(
+    () => selectedChannel.trajectory[safeStepIndex],
+    [selectedChannel, safeStepIndex]
+  );
+
+  const timeValue = prediction.times[Math.min(safeStepIndex, prediction.times.length - 1)];
+
+  const heatmapData = useMemo(
+    () => [
+      {
+        z: activeStep.data,
+        type: 'heatmap',
+        colorscale: 'RdBu',
+        reversescale: true,
+        zsmooth: 'best'
+      }
+    ],
+    [activeStep]
+  );
+
+  return (
+    <section className="section-card">
+      <div className="prediction-header">
+        <div>
+          <h2>Prediction explorer</h2>
+          <p>Inspect the generated trajectory for any channel and time step.</p>
+        </div>
+        <div className="prediction-stats">
+          <div>
+            <span>RMSE</span>
+            <strong>{selectedChannel.rmse.toFixed(4)}</strong>
+          </div>
+          <div>
+            <span>MAE</span>
+            <strong>{selectedChannel.mae.toFixed(4)}</strong>
+          </div>
+          <div>
+            <span>Baseline RMSE</span>
+            <strong>{selectedChannel.baselineRmse.toFixed(4)}</strong>
+          </div>
+        </div>
+      </div>
+
+      <div className="prediction-controls">
+        <label>
+          Channel
+          <select value={channelIndex} onChange={(event) => setChannelIndex(Number(event.target.value))}>
+            {channels.map((channel, index) => (
+              <option key={channel.name} value={index}>
+                {channel.name.toUpperCase()}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="slider-label">
+          Time step
+          <input
+            type="range"
+            min={0}
+            max={sliderMax}
+            value={stepIndex}
+            onChange={(event) => setStepIndex(Number(event.target.value))}
+          />
+          <span className="slider-value">t={timeValue !== undefined ? timeValue.toFixed(2) : 'n/a'}</span>
+        </label>
+      </div>
+
+      <div className="heatmap-grid">
+        <Plot
+          data={heatmapData}
+          layout={{
+            autosize: true,
+            margin: { t: 30, r: 30, b: 40, l: 60 },
+            paper_bgcolor: 'rgba(0,0,0,0)',
+            plot_bgcolor: 'rgba(0,0,0,0)',
+            height: 360,
+            xaxis: { title: 'Longitude' },
+            yaxis: { title: 'Latitude' }
+          }}
+          style={{ width: '100%', height: '100%' }}
+          config={{ displayModeBar: false, responsive: true }}
+        />
+        <div className="comparison-panels">
+          <div>
+            <h3>Initial</h3>
+            <Plot
+              data={[
+                {
+                  z: selectedChannel.initial,
+                  type: 'heatmap',
+                  colorscale: 'RdBu',
+                  reversescale: true
+                }
+              ]}
+              layout={{
+                autosize: true,
+                margin: { t: 30, r: 30, b: 40, l: 60 },
+                height: 260,
+                paper_bgcolor: 'rgba(0,0,0,0)',
+                plot_bgcolor: 'rgba(0,0,0,0)',
+                xaxis: { title: 'Lon' },
+                yaxis: { title: 'Lat' }
+              }}
+              style={{ width: '100%', height: '100%' }}
+              config={{ displayModeBar: false, responsive: true }}
+            />
+          </div>
+          <div>
+            <h3>Target</h3>
+            <Plot
+              data={[
+                {
+                  z: selectedChannel.target,
+                  type: 'heatmap',
+                  colorscale: 'RdBu',
+                  reversescale: true
+                }
+              ]}
+              layout={{
+                autosize: true,
+                margin: { t: 30, r: 30, b: 40, l: 60 },
+                height: 260,
+                paper_bgcolor: 'rgba(0,0,0,0)',
+                plot_bgcolor: 'rgba(0,0,0,0)',
+                xaxis: { title: 'Lon' },
+                yaxis: { title: 'Lat' }
+              }}
+              style={{ width: '100%', height: '100%' }}
+              config={{ displayModeBar: false, responsive: true }}
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default PredictionViewer;

--- a/frontend/src/components/ResultsPanel.tsx
+++ b/frontend/src/components/ResultsPanel.tsx
@@ -1,0 +1,46 @@
+import { ExperimentResult } from '../api/types';
+import DatasetStats from './DatasetStats';
+import LossChart from './LossChart';
+import PredictionViewer from './PredictionViewer';
+import SummaryPanel from './SummaryPanel';
+
+interface Props {
+  result: ExperimentResult | null;
+  loading: boolean;
+  hasConfig: boolean;
+}
+
+function ResultsPanel({ result, loading, hasConfig }: Props): JSX.Element {
+  if (loading && !result) {
+    return (
+      <section className="section-card">
+        <h2>Running experiment…</h2>
+        <p>Training the WeatherFlow model with the selected configuration.</p>
+      </section>
+    );
+  }
+
+  if (!result) {
+    return (
+      <section className="section-card">
+        <h2>Experiment results</h2>
+        <p>
+          {hasConfig
+            ? 'Adjust the configuration on the left and click “Run experiment” to generate results.'
+            : 'Select at least one variable and pressure level to begin.'}
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <div className="results-stack">
+      <SummaryPanel result={result} />
+      <LossChart train={result.metrics.train} validation={result.validation.metrics} />
+      <PredictionViewer prediction={result.prediction} />
+      <DatasetStats stats={result.datasetSummary.channelStats} />
+    </div>
+  );
+}
+
+export default ResultsPanel;

--- a/frontend/src/components/SummaryPanel.tsx
+++ b/frontend/src/components/SummaryPanel.tsx
@@ -1,0 +1,90 @@
+import { ExperimentResult } from '../api/types';
+import { formatSeconds } from '../utils/format';
+
+interface Props {
+  result: ExperimentResult;
+}
+
+function SummaryPanel({ result }: Props): JSX.Element {
+  const { dataset, model, training } = result.config;
+  const duration = formatSeconds(result.execution.durationSeconds);
+
+  return (
+    <section className="section-card">
+      <div className="summary-header">
+        <div>
+          <h2>Experiment summary</h2>
+          <p>Experiment ID: {result.experimentId}</p>
+        </div>
+        <div className="summary-duration">Runtime: {duration}</div>
+      </div>
+
+      <div className="summary-grid">
+        <div>
+          <h3>Dataset</h3>
+          <ul>
+            <li>
+              Variables:{' '}
+              <strong>{dataset.variables.map((item) => item.toUpperCase()).join(', ')}</strong>
+            </li>
+            <li>
+              Pressure levels:{' '}
+              <strong>{dataset.pressureLevels.join(', ')}</strong>
+            </li>
+            <li>
+              Grid:{' '}
+              <strong>
+                {dataset.gridSize.lat} × {dataset.gridSize.lon}
+              </strong>
+            </li>
+            <li>
+              Samples:{' '}
+              <strong>
+                {dataset.trainSamples} train / {dataset.valSamples} val
+              </strong>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <h3>Model</h3>
+          <ul>
+            <li>
+              Hidden dimension: <strong>{model.hiddenDim}</strong>
+            </li>
+            <li>
+              Layers: <strong>{model.nLayers}</strong>
+            </li>
+            <li>
+              Attention: <strong>{model.useAttention ? 'enabled' : 'disabled'}</strong>
+            </li>
+            <li>
+              Physics constraints: <strong>{model.physicsInformed ? 'enabled' : 'disabled'}</strong>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <h3>Training</h3>
+          <ul>
+            <li>
+              Epochs: <strong>{training.epochs}</strong>
+            </li>
+            <li>
+              Batch size: <strong>{training.batchSize}</strong>
+            </li>
+            <li>
+              Learning rate: <strong>{training.learningRate}</strong>
+            </li>
+            <li>
+              Loss: <strong>{training.lossType.toUpperCase()}</strong>
+            </li>
+            <li>
+              Solver: <strong>{training.solverMethod.toUpperCase()}</strong>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default SummaryPanel;

--- a/frontend/src/components/TrainingConfigurator.tsx
+++ b/frontend/src/components/TrainingConfigurator.tsx
@@ -1,0 +1,136 @@
+import { ChangeEvent } from 'react';
+import { LossType, ServerOptions, TrainingConfig } from '../api/types';
+
+interface Props {
+  options: ServerOptions | null;
+  value: TrainingConfig | null;
+  onChange: (config: TrainingConfig) => void;
+}
+
+function TrainingConfigurator({ options, value, onChange }: Props): JSX.Element {
+  const handleNumberChange = (event: ChangeEvent<HTMLInputElement>) => {
+    if (!value) {
+      return;
+    }
+    const { name, value: raw } = event.target;
+    const numeric = Number(raw);
+    onChange({ ...value, [name]: Number.isNaN(numeric) ? 0 : numeric });
+  };
+
+  const handleSolverChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    if (!value) {
+      return;
+    }
+    onChange({ ...value, solverMethod: event.target.value });
+  };
+
+  const handleLossChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    if (!value) {
+      return;
+    }
+    onChange({ ...value, lossType: event.target.value as LossType });
+  };
+
+  if (!options || !value) {
+    return (
+      <section className="section-card">
+        <h2>Training setup</h2>
+        <p>Waiting for server options…</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="section-card">
+      <div>
+        <h2>Training setup</h2>
+        <p>Specify the optimisation hyperparameters and solver for evaluation.</p>
+      </div>
+      <div className="form-grid">
+        <label>
+          Epochs
+          <input
+            type="number"
+            min={1}
+            max={options.maxEpochs}
+            name="epochs"
+            value={value.epochs}
+            onChange={handleNumberChange}
+          />
+        </label>
+        <label>
+          Batch size
+          <input
+            type="number"
+            min={1}
+            max={64}
+            name="batchSize"
+            value={value.batchSize}
+            onChange={handleNumberChange}
+          />
+        </label>
+        <label>
+          Learning rate
+          <input
+            type="number"
+            step="0.0001"
+            min={0.0001}
+            max={0.01}
+            name="learningRate"
+            value={value.learningRate}
+            onChange={handleNumberChange}
+          />
+        </label>
+        <label>
+          Time steps
+          <input
+            type="number"
+            min={3}
+            max={12}
+            name="timeSteps"
+            value={value.timeSteps}
+            onChange={handleNumberChange}
+          />
+        </label>
+        <label>
+          Dynamics scale
+          <input
+            type="number"
+            step="0.01"
+            min={0.05}
+            max={0.5}
+            name="dynamicsScale"
+            value={value.dynamicsScale}
+            onChange={handleNumberChange}
+          />
+        </label>
+        <label>
+          Random seed
+          <input type="number" min={0} max={10000} name="seed" value={value.seed} onChange={handleNumberChange} />
+        </label>
+        <label>
+          ODE solver
+          <select value={value.solverMethod} onChange={handleSolverChange}>
+            {options.solverMethods.map((method) => (
+              <option key={method} value={method}>
+                {method.toUpperCase()}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Loss function
+          <select value={value.lossType} onChange={handleLossChange}>
+            {options.lossTypes.map((loss) => (
+              <option key={loss} value={loss}>
+                {loss.toUpperCase()}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+    </section>
+  );
+}
+
+export default TrainingConfigurator;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,22 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color-scheme: light dark;
+  color: #1a1a1a;
+  background-color: #f2f4f8;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f5f7fb 0%, #eef2f7 100%);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+button {
+  font-family: inherit;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -1,0 +1,17 @@
+export function formatSeconds(seconds: number): string {
+  if (Number.isNaN(seconds) || !Number.isFinite(seconds)) {
+    return 'n/a';
+  }
+
+  if (seconds < 1) {
+    return `${(seconds * 1000).toFixed(0)} ms`;
+  }
+
+  if (seconds < 60) {
+    return `${seconds.toFixed(1)} s`;
+  }
+
+  const minutes = Math.floor(seconds / 60);
+  const remainder = seconds % 60;
+  return `${minutes}m ${remainder.toFixed(0)}s`;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.node.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/setupTests.ts'],
+    globals: true
+  }
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ dependencies = [
     "scipy>=1.7.0",
     "torchdiffeq>=0.2.3",  # Added for ODE solvers
     "plotly>=5.18.0",
+    "fastapi>=0.110.0,<0.112.0",
+    "uvicorn>=0.23.0,<0.28.0",
 ]
 
 [[project.authors]]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,6 @@ flake8-docstrings>=1.7.0
 mypy>=1.3.0
 pre-commit>=3.3.3
 nbstripout>=0.6.1
+fastapi>=0.110.0,<0.112.0
+uvicorn>=0.23.0,<0.28.0
+httpx>=0.24.0

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,53 @@
+"""Tests for the WeatherFlow FastAPI server."""
+from fastapi.testclient import TestClient
+
+from weatherflow.server.app import create_app
+
+client = TestClient(create_app())
+
+
+def test_options_endpoint() -> None:
+    response = client.get("/api/options")
+    assert response.status_code == 200
+    payload = response.json()
+    assert "variables" in payload
+    assert payload["variables"]
+    assert "pressureLevels" in payload
+
+
+def test_experiment_endpoint() -> None:
+    payload = {
+        "dataset": {
+            "variables": ["t", "z"],
+            "pressureLevels": [500],
+            "gridSize": {"lat": 8, "lon": 16},
+            "trainSamples": 12,
+            "valSamples": 6
+        },
+        "model": {
+            "hiddenDim": 48,
+            "nLayers": 2,
+            "useAttention": False,
+            "physicsInformed": True
+        },
+        "training": {
+            "epochs": 1,
+            "batchSize": 4,
+            "learningRate": 0.001,
+            "solverMethod": "rk4",
+            "timeSteps": 3,
+            "lossType": "mse",
+            "seed": 7,
+            "dynamicsScale": 0.1
+        }
+    }
+
+    response = client.post("/api/experiments", json=payload)
+    assert response.status_code == 200, response.text
+    data = response.json()
+
+    assert data["config"]["dataset"]["trainSamples"] == payload["dataset"]["trainSamples"]
+    assert data["metrics"]["train"][0]["epoch"] == 1
+    assert data["prediction"]["channels"], "Channels should be returned"
+    assert data["datasetSummary"]["channelStats"]
+    assert data["execution"]["durationSeconds"] > 0

--- a/weatherflow/server/__init__.py
+++ b/weatherflow/server/__init__.py
@@ -1,0 +1,5 @@
+"""FastAPI integration for the WeatherFlow experimentation service."""
+
+from .app import create_app
+
+__all__ = ["create_app"]

--- a/weatherflow/server/app.py
+++ b/weatherflow/server/app.py
@@ -1,0 +1,516 @@
+"""FastAPI application exposing WeatherFlow experimentation utilities."""
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Dict, List
+
+import torch
+import torch.nn.functional as F
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field, validator
+from torch.utils.data import DataLoader, TensorDataset
+
+from weatherflow.models.flow_matching import WeatherFlowMatch, WeatherFlowODE
+
+# Limit CPU usage for deterministic behaviour when running inside tests
+TORCH_NUM_THREADS = 1
+
+torch.set_num_threads(TORCH_NUM_THREADS)
+
+DEFAULT_VARIABLES = ["t", "z", "u", "v"]
+DEFAULT_PRESSURE_LEVELS = [1000, 850, 700, 500, 300, 200]
+DEFAULT_GRID_SIZES = [(16, 32), (32, 64)]
+DEFAULT_SOLVER_METHODS = ["dopri5", "rk4", "midpoint"]
+DEFAULT_LOSS_TYPES = ["mse", "huber", "smooth_l1"]
+
+
+class CamelModel(BaseModel):
+    """Base model enabling population by field name or alias."""
+
+    class Config:
+        allow_population_by_field_name = True
+
+
+class GridSize(CamelModel):
+    """Simple grid size model for validation."""
+
+    lat: int = Field(16, ge=4, le=128)
+    lon: int = Field(32, ge=4, le=256)
+
+    @validator("lon")
+    def lon_multiple_of_two(cls, value: int) -> int:  # noqa: D401
+        """Ensure longitude dimension is even for nicer plots."""
+        if value % 2 != 0:
+            raise ValueError("Longitude must be an even number")
+        return value
+
+
+class DatasetConfig(CamelModel):
+    """Configuration options for generating synthetic datasets."""
+
+    variables: List[str] = Field(default_factory=lambda: DEFAULT_VARIABLES[:2])
+    pressure_levels: List[int] = Field(default_factory=lambda: [500], alias="pressureLevels")
+    grid_size: GridSize = Field(default_factory=GridSize, alias="gridSize")
+    train_samples: int = Field(48, ge=4, le=256, alias="trainSamples")
+    val_samples: int = Field(16, ge=4, le=128, alias="valSamples")
+
+    @validator("variables")
+    def validate_variables(cls, values: List[str]) -> List[str]:  # noqa: D401
+        """Ensure at least one variable was selected."""
+        if not values:
+            raise ValueError("At least one variable must be selected")
+        for var in values:
+            if var not in DEFAULT_VARIABLES:
+                raise ValueError(f"Unsupported variable '{var}'")
+        return values
+
+    @validator("pressure_levels")
+    def validate_pressure_levels(cls, values: List[int]) -> List[int]:  # noqa: D401
+        """Ensure at least one pressure level is available."""
+        if not values:
+            raise ValueError("Select at least one pressure level")
+        return values
+
+
+class ModelConfig(CamelModel):
+    """Neural network hyperparameters."""
+
+    hidden_dim: int = Field(96, ge=32, le=512, alias="hiddenDim")
+    n_layers: int = Field(3, ge=1, le=8, alias="nLayers")
+    use_attention: bool = Field(True, alias="useAttention")
+    physics_informed: bool = Field(True, alias="physicsInformed")
+
+
+class TrainingConfig(CamelModel):
+    """Training loop configuration."""
+
+    epochs: int = Field(2, ge=1, le=6)
+    batch_size: int = Field(8, ge=1, le=64, alias="batchSize")
+    learning_rate: float = Field(5e-4, gt=0, le=1e-2, alias="learningRate")
+    solver_method: str = Field("dopri5", alias="solverMethod")
+    time_steps: int = Field(5, ge=3, le=12, alias="timeSteps")
+    loss_type: str = Field("mse", alias="lossType")
+    seed: int = Field(42, ge=0, le=10_000)
+    dynamics_scale: float = Field(0.15, gt=0.01, le=0.5, alias="dynamicsScale")
+
+    @validator("solver_method")
+    def solver_method_supported(cls, value: str) -> str:  # noqa: D401
+        """Ensure the requested ODE solver is available."""
+        if value not in DEFAULT_SOLVER_METHODS:
+            raise ValueError(f"Unsupported solver '{value}'")
+        return value
+
+    @validator("loss_type")
+    def loss_type_supported(cls, value: str) -> str:  # noqa: D401
+        """Ensure the loss type is compatible with the training loop."""
+        if value not in DEFAULT_LOSS_TYPES:
+            raise ValueError(f"Unsupported loss '{value}'")
+        return value
+
+
+class ExperimentConfig(CamelModel):
+    """Bundled configuration used by the API endpoint."""
+
+    dataset: DatasetConfig = Field(default_factory=DatasetConfig)
+    model: ModelConfig = Field(default_factory=ModelConfig)
+    training: TrainingConfig = Field(default_factory=TrainingConfig)
+
+
+class ChannelStats(CamelModel):
+    name: str
+    mean: float
+    std: float
+    min: float
+    max: float
+
+
+class MetricEntry(CamelModel):
+    epoch: int
+    loss: float
+    flow_loss: float = Field(alias="flowLoss")
+    divergence_loss: float = Field(alias="divergenceLoss")
+    energy_diff: float = Field(alias="energyDiff")
+
+
+class ValidationMetricEntry(CamelModel):
+    epoch: int
+    val_loss: float
+    val_flow_loss: float = Field(alias="valFlowLoss")
+    val_divergence_loss: float = Field(alias="valDivergenceLoss")
+    val_energy_diff: float = Field(alias="valEnergyDiff")
+
+
+class TrajectoryStep(CamelModel):
+    time: float
+    data: List[List[float]]
+
+
+class ChannelTrajectory(CamelModel):
+    name: str
+    initial: List[List[float]]
+    target: List[List[float]]
+    trajectory: List[TrajectoryStep]
+    rmse: float
+    mae: float
+    baseline_rmse: float = Field(alias="baselineRmse")
+
+
+class PredictionResult(CamelModel):
+    times: List[float]
+    channels: List[ChannelTrajectory]
+
+
+class ExecutionSummary(CamelModel):
+    duration_seconds: float = Field(alias="durationSeconds")
+
+
+class DatasetSummary(CamelModel):
+    channel_stats: List[ChannelStats] = Field(alias="channelStats")
+    sample_shape: List[int] = Field(alias="sampleShape")
+
+
+class ExperimentResult(CamelModel):
+    experiment_id: str = Field(alias="experimentId")
+    config: ExperimentConfig
+    channel_names: List[str] = Field(alias="channelNames")
+    metrics: Dict[str, List[MetricEntry]]
+    validation: Dict[str, List[ValidationMetricEntry]]
+    dataset_summary: DatasetSummary = Field(alias="datasetSummary")
+    prediction: PredictionResult
+    execution: ExecutionSummary
+
+
+def _channel_names(dataset: DatasetConfig) -> List[str]:
+    names: List[str] = []
+    for var in dataset.variables:
+        for level in dataset.pressure_levels:
+            names.append(f"{var}@{level}")
+    return names
+
+
+def _build_dataloaders(config: DatasetConfig, dynamics_scale: float) -> Dict[str, object]:
+    """Create lightweight synthetic datasets for demonstration purposes."""
+    channel_names = _channel_names(config)
+    channels = len(channel_names)
+    lat = config.grid_size.lat
+    lon = config.grid_size.lon
+
+    def _synth_samples(num_samples: int) -> torch.Tensor:
+        base = torch.randn(num_samples, channels, lat, lon)
+        return base
+
+    train_x0 = _synth_samples(config.train_samples)
+    train_x1 = train_x0 + dynamics_scale * torch.randn_like(train_x0)
+
+    val_x0 = _synth_samples(config.val_samples)
+    val_x1 = val_x0 + dynamics_scale * torch.randn_like(val_x0)
+
+    train_dataset = TensorDataset(train_x0, train_x1)
+    val_dataset = TensorDataset(val_x0, val_x1)
+    return {
+        "train": train_dataset,
+        "val": val_dataset,
+        "channel_names": channel_names,
+    }
+
+
+def _aggregate_channel_stats(data: torch.Tensor, names: List[str]) -> List[ChannelStats]:
+    """Compute simple summary statistics per channel."""
+    stats: List[ChannelStats] = []
+    reshaped = data.reshape(data.shape[0], data.shape[1], -1)
+    for idx, name in enumerate(names):
+        channel = reshaped[:, idx]
+        stats.append(
+            ChannelStats(
+                name=name,
+                mean=float(channel.mean()),
+                std=float(channel.std(unbiased=False)),
+                min=float(channel.min()),
+                max=float(channel.max()),
+            )
+        )
+    return stats
+
+
+def _compute_losses(
+    model: WeatherFlowMatch,
+    x0: torch.Tensor,
+    x1: torch.Tensor,
+    t: torch.Tensor,
+    loss_type: str,
+) -> Dict[str, torch.Tensor]:
+    """Compute flow matching loss with optional physics constraints."""
+
+    v_pred = model(x0, t)
+    target_velocity = (x1 - x0) / (1 - t).view(-1, 1, 1, 1)
+
+    if loss_type == "huber":
+        flow_loss = F.huber_loss(v_pred, target_velocity, delta=1.0)
+    elif loss_type == "smooth_l1":
+        flow_loss = F.smooth_l1_loss(v_pred, target_velocity)
+    else:
+        flow_loss = F.mse_loss(v_pred, target_velocity)
+
+    losses: Dict[str, torch.Tensor] = {
+        "flow_loss": flow_loss,
+        "total_loss": flow_loss,
+    }
+
+    if model.physics_informed:
+        if v_pred.shape[1] >= 2:
+            u = v_pred[:, 0:1]
+            v_comp = v_pred[:, 1:2]
+            du_dx = torch.gradient(u, dim=3)[0]
+            dv_dy = torch.gradient(v_comp, dim=2)[0]
+            div = du_dx + dv_dy
+            div_loss = torch.mean(div**2)
+            losses["div_loss"] = div_loss
+            losses["total_loss"] = losses["total_loss"] + 0.1 * div_loss
+
+        energy_x0 = torch.sum(x0**2)
+        energy_x1 = torch.sum(x1**2)
+        energy_diff = (energy_x0 - energy_x1).abs() / (energy_x0 + 1e-6)
+        losses["energy_diff"] = energy_diff
+
+    return losses
+
+
+def _prepare_trajectory(
+    predictions: torch.Tensor,
+    initial: torch.Tensor,
+    target: torch.Tensor,
+    times: torch.Tensor,
+    names: List[str],
+) -> PredictionResult:
+    channels: List[ChannelTrajectory] = []
+    for channel_idx, name in enumerate(names):
+        channel_predictions = predictions[:, 0, channel_idx].detach().cpu()
+        channel_initial = initial[0, channel_idx].detach().cpu()
+        channel_target = target[0, channel_idx].detach().cpu()
+
+        rmse = torch.sqrt(torch.mean((channel_predictions[-1] - channel_target) ** 2)).item()
+        mae = torch.mean(torch.abs(channel_predictions[-1] - channel_target)).item()
+        baseline_rmse = torch.sqrt(torch.mean((channel_initial - channel_target) ** 2)).item()
+
+        trajectory = [
+            TrajectoryStep(time=float(times[i].item()), data=channel_predictions[i].tolist())
+            for i in range(len(times))
+        ]
+
+        channels.append(
+            ChannelTrajectory(
+                name=name,
+                initial=channel_initial.tolist(),
+                target=channel_target.tolist(),
+                trajectory=trajectory,
+                rmse=float(rmse),
+                mae=float(mae),
+                baseline_rmse=float(baseline_rmse),
+            )
+        )
+
+    return PredictionResult(
+        times=[float(t.item()) for t in times],
+        channels=channels,
+    )
+
+
+def _train_model(
+    config: ExperimentConfig,
+    device: torch.device,
+    datasets: Dict[str, object],
+) -> Dict[str, object]:
+    channel_names: List[str] = datasets["channel_names"]
+    train_dataset: TensorDataset = datasets["train"]
+    val_dataset: TensorDataset = datasets["val"]
+
+    train_loader = DataLoader(
+        train_dataset,
+        batch_size=min(config.training.batch_size, len(train_dataset)),
+        shuffle=True,
+    )
+    val_loader = DataLoader(
+        val_dataset,
+        batch_size=min(config.training.batch_size, len(val_dataset)),
+        shuffle=False,
+    )
+
+    model = WeatherFlowMatch(
+        input_channels=len(channel_names),
+        hidden_dim=config.model.hidden_dim,
+        n_layers=config.model.n_layers,
+        use_attention=config.model.use_attention,
+        grid_size=(config.dataset.grid_size.lat, config.dataset.grid_size.lon),
+        physics_informed=config.model.physics_informed,
+    ).to(device)
+
+    optimizer = torch.optim.Adam(model.parameters(), lr=config.training.learning_rate)
+
+    train_metrics: List[MetricEntry] = []
+    val_metrics: List[ValidationMetricEntry] = []
+
+    for epoch in range(config.training.epochs):
+        model.train()
+        train_loss = []
+        train_flow = []
+        train_div = []
+        train_energy = []
+
+        for x0, x1 in train_loader:
+            x0 = x0.to(device)
+            x1 = x1.to(device)
+            t = torch.rand(x0.size(0), device=device)
+
+            losses = _compute_losses(model, x0, x1, t, config.training.loss_type)
+            total_loss = losses["total_loss"]
+
+            optimizer.zero_grad()
+            total_loss.backward()
+            optimizer.step()
+
+            train_loss.append(float(total_loss.item()))
+            train_flow.append(float(losses["flow_loss"].item()))
+            train_div.append(float(losses.get("div_loss", torch.tensor(0.0)).item()))
+            train_energy.append(float(losses.get("energy_diff", torch.tensor(0.0)).item()))
+
+        if not train_loss:
+            raise RuntimeError("Training dataset is empty")
+
+        train_metrics.append(
+            MetricEntry(
+                epoch=epoch + 1,
+                loss=float(sum(train_loss) / len(train_loss)),
+                flow_loss=float(sum(train_flow) / len(train_flow)),
+                divergence_loss=float(sum(train_div) / len(train_div)),
+                energy_diff=float(sum(train_energy) / len(train_energy)),
+            )
+        )
+
+        model.eval()
+        val_loss = []
+        val_flow = []
+        val_div = []
+        val_energy = []
+
+        with torch.no_grad():
+            for x0, x1 in val_loader:
+                x0 = x0.to(device)
+                x1 = x1.to(device)
+                t = torch.rand(x0.size(0), device=device)
+
+                losses = _compute_losses(model, x0, x1, t, config.training.loss_type)
+                total_loss = losses["total_loss"]
+
+                val_loss.append(float(total_loss.item()))
+                val_flow.append(float(losses["flow_loss"].item()))
+                val_div.append(float(losses.get("div_loss", torch.tensor(0.0)).item()))
+                val_energy.append(float(losses.get("energy_diff", torch.tensor(0.0)).item()))
+
+        val_metrics.append(
+            ValidationMetricEntry(
+                epoch=epoch + 1,
+                val_loss=float(sum(val_loss) / len(val_loss)),
+                val_flow_loss=float(sum(val_flow) / len(val_flow)),
+                val_divergence_loss=float(sum(val_div) / len(val_div)),
+                val_energy_diff=float(sum(val_energy) / len(val_energy)),
+            )
+        )
+
+    return {
+        "model": model,
+        "train_metrics": train_metrics,
+        "val_metrics": val_metrics,
+    }
+
+
+def _run_prediction(
+    model: WeatherFlowMatch,
+    config: ExperimentConfig,
+    dataset: TensorDataset,
+    channel_names: List[str],
+    device: torch.device,
+) -> PredictionResult:
+    model.eval()
+    ode_model = WeatherFlowODE(
+        model,
+        solver_method=config.training.solver_method,
+    ).to(device)
+    times = torch.linspace(0.0, 1.0, config.training.time_steps, device=device)
+
+    initial, target = dataset.tensors[0][:1].to(device), dataset.tensors[1][:1].to(device)
+
+    with torch.no_grad():
+        predictions = ode_model(initial, times)
+
+    return _prepare_trajectory(predictions, initial, target, times, channel_names)
+
+
+def _build_dataset_summary(dataset: TensorDataset, channel_names: List[str]) -> DatasetSummary:
+    x0 = dataset.tensors[0]
+    stats = _aggregate_channel_stats(x0, channel_names)
+    return DatasetSummary(
+        channel_stats=stats,
+        sample_shape=list(x0.shape[1:]),
+    )
+
+
+def create_app() -> FastAPI:
+    """Create the FastAPI instance used by both the CLI and tests."""
+    app = FastAPI(title="WeatherFlow API", version="1.0")
+
+    @app.get("/api/options")
+    def get_options() -> Dict[str, object]:  # noqa: D401
+        """Return enumerations consumed by the front-end."""
+        return {
+            "variables": DEFAULT_VARIABLES,
+            "pressureLevels": DEFAULT_PRESSURE_LEVELS,
+            "gridSizes": [
+                {"lat": lat, "lon": lon} for lat, lon in DEFAULT_GRID_SIZES
+            ],
+            "solverMethods": DEFAULT_SOLVER_METHODS,
+            "lossTypes": DEFAULT_LOSS_TYPES,
+            "maxEpochs": 6,
+        }
+
+    @app.get("/api/health")
+    def health() -> Dict[str, str]:
+        return {"status": "ok"}
+
+    @app.post("/api/experiments", response_model=ExperimentResult)
+    def run_experiment(config: ExperimentConfig) -> ExperimentResult:
+        start = time.perf_counter()
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+        try:
+            torch.manual_seed(config.training.seed)
+            datasets = _build_dataloaders(config.dataset, config.training.dynamics_scale)
+            training_outcome = _train_model(config, device, datasets)
+            prediction = _run_prediction(
+                training_outcome["model"],
+                config,
+                datasets["val"],
+                datasets["channel_names"],
+                device,
+            )
+            summary = _build_dataset_summary(datasets["train"], datasets["channel_names"])
+        except Exception as exc:  # pragma: no cover - surfaced to API response
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        end = time.perf_counter()
+
+        return ExperimentResult(
+            experiment_id=str(uuid.uuid4()),
+            config=config,
+            channel_names=datasets["channel_names"],
+            metrics={"train": training_outcome["train_metrics"]},
+            validation={"metrics": training_outcome["val_metrics"]},
+            dataset_summary=summary,
+            prediction=prediction,
+            execution=ExecutionSummary(duration_seconds=float(end - start)),
+        )
+
+    return app
+
+
+app = create_app()


### PR DESCRIPTION
## Summary
- add a FastAPI service that wraps WeatherFlow models for synthetic training, validation, and inference
- build a Vite/React dashboard that configures datasets, models, and training runs and visualises the returned metrics
- extend docs and tests to cover the new API endpoints and frontend workflow

## Testing
- `pytest` *(fails: missing fastapi dependency in offline environment)*
- `flake8 weatherflow` *(fails: flake8 not available in offline environment)*
- `npm install && npm run build && npm test` *(fails: npm registry blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9cd43da14832db676db2fc5f0aa0c