### PR TITLE
docs: overhaul documentation and tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,19 @@ visualizer.plot_comparison(
 )
 ```
 
+## Documentation
+
+The `docs/` directory contains an extensive MkDocs site covering installation,
+data ingestion, model APIs, advanced usage patterns, and tutorials. Build it
+locally with:
+
+```bash
+pip install -e .[docs]
+mkdocs serve
+```
+
+Then open `http://localhost:8000` to browse the rendered documentation.
+
 ## Comprehensive Example
 
 For a more comprehensive example, see the `examples/weather_prediction.py` script, which demonstrates:

--- a/docs/advanced_topics/flow_matching_implementation.md
+++ b/docs/advanced_topics/flow_matching_implementation.md
@@ -1,30 +1,85 @@
+# Flow Matching Implementation Guide
 
-# Flow Matching Implementation
+This guide connects the high-level theory to the concrete implementation inside
+WeatherFlow. It highlights how the probability paths, spherical geometry
+routines, and solvers interact when you train and integrate a flow model.
 
-## Overview
-This section details our implementation of flow matching for weather prediction, which integrates:
-- Probability paths on manifolds
-- Spherical geometry for Earth's surface
-- Physics-constrained ODE solvers
+## Probability paths and schedules
 
-## Core Components
+The core abstractions live in `weatherflow.path`:
 
-### Probability Paths
-The `ProbPath` class provides the foundation for continuous-time flow matching:
+- [`ProbPath`](../../weatherflow/path/prob_path.py) defines the interface for
+  sampling points along a path and for retrieving the flow vector field at time
+  \(t\).
+- [`GaussianProbPath`](../../weatherflow/path/gaussian_path.py) implements the
+  conditional Gaussian path \(\mathcal{N}(\alpha_t z, \beta_t^2 I)\) used
+  throughout the examples. It exposes helper methods to compute analytic scores
+  and vector fields, along with `sample_conditional(...)` for data-dependent
+  draws.
+- [`CondOTPath`](../../weatherflow/path/condot_path.py) demonstrates how to plug
+  in alternative schedules such as conditional optimal transport.
 
-### Spherical Manifold
-The `Sphere` class handles geometric operations on Earth's surface:
+The conversion utilities in `weatherflow.models.conversion` bridge score-based
+and vector-field parameterisations by implementing Proposition 1 from the flow
+matching lecture notes. Use them to wrap custom score networks or to export a
+trained vector field as a score model for diffusion experiments.
 
-### Weather ODE Solver
-The `WeatherODESolver` manages time evolution with physics constraints:
+## Working on the sphere
 
-## Integration Example
+Global weather modelling requires respecting Earth's spherical geometry.
+`weatherflow.manifolds.Sphere` provides numerically stable exponential and
+logarithmic maps, geodesic interpolation, and parallel transport. These routines
+operate on three-dimensional Cartesian coordinates and include dtype-aware
+stability safeguards that prevent floating-point breakdowns when vectors are
+nearly aligned.
 
-## Physics Constraints
-The implementation maintains:
-- Mass conservation through divergence-free velocity fields
-- Energy conservation via soft constraints
-- Proper spherical geometry for Earth's surface
+The manifold utilities are used by the higher-level `WeatherFlowModel` and can
+be incorporated into custom models when you need geodesic interpolation between
+states or to project intermediate results back onto the sphere.
 
-## Advanced Usage
-See the examples directory for detailed implementations.
+## ODE solver with physics constraints
+
+[`WeatherODESolver`](../../weatherflow/solvers/ode_solver.py) is the workhorse
+solver that integrates the learned velocity field while optionally enforcing
+physical constraints:
+
+- **Mass conservation** – approximated by subtracting the gradient of the
+  divergence from the \(u\) and \(v\) wind components.
+- **Energy conservation** – normalises the velocity magnitude relative to the
+  current state energy and tracks drift statistics.
+- **Vorticity control** – adds a rotational correction derived from the curl of
+  the flow field.
+
+The solver keeps running statistics on constraint violations and energy drift so
+you can assess stability. It also exposes knobs for relative/absolute tolerances
+and supports multiple integration methods (Dopri5, RK4, midpoint).
+
+## Training loop integration
+
+`FlowTrainer` stitches everything together:
+
+1. Samples \(t \sim \mathcal{U}(0, 1)\) for each batch element.
+2. Calls the model to evaluate the velocity field \(u_t(x)\).
+3. Computes the straight-line target velocity and the loss via
+   `compute_flow_loss` (with optional Huber/Smooth-L1 variants).
+4. Applies physics regularisation by delegating to
+   `model.compute_physics_loss(...)` when available.
+5. Steps the optimiser with optional AMP scaling and scheduler updates.
+
+Models such as `WeatherFlowMatch` embed light-weight divergence projection and
+energy checks in their own loss functions, providing an additional layer of
+physical awareness.
+
+## Putting the pieces together
+
+A typical experiment will:
+
+1. Instantiate a probability path (Gaussian by default).
+2. Train `WeatherFlowMatch` or another model with `FlowTrainer`.
+3. Wrap the trained model with `WeatherFlowODE` or feed it into
+   `WeatherODESolver` for trajectory integration.
+4. Use `WeatherVisualizer` or the Plotly-based tools to analyse results.
+
+The examples in `examples/weather_prediction.py` and the
+[Advanced Usage](../advanced_usage.md) page provide concrete scripts that tie
+these components into reproducible workflows.

--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -1,16 +1,180 @@
 # Advanced Usage Guide
 
-## Custom Physics Constraints
+This page collects battle-tested patterns for running larger experiments,
+integrating WeatherFlow with other services, and taking advantage of the more
+specialised utilities bundled with the library.
 
-You can add custom physics constraints to the PhysicsGuidedAttention model:
+## Train at scale with `FlowTrainer`
 
+`FlowTrainer` already includes features you typically need in a research loop:
 
-## ERA5 Data Processing
+- **Mixed precision** via PyTorch AMP (`use_amp=True` by default on CUDA).
+- **Physics regularisation** by calling `model.compute_physics_loss` when the
+  model implements it (`physics_regularization=True`).
+- **Configurable loss surfaces** through the `loss_type` parameter
+  (`"mse"`, `"huber"`, or `"smooth_l1"`).
+- **Checkpointing** with `save_checkpoint`/`load_checkpoint` and an optional
+  scheduler slot.
 
-Advanced data loading and preprocessing:
+Example configuration with logging and checkpoints:
 
+```python
+import torch
+from weatherflow.training.flow_trainer import FlowTrainer
 
-## Custom Training Loops
+optimizer = torch.optim.AdamW(model.parameters(), lr=3e-4, weight_decay=1e-5)
+trainer = FlowTrainer(
+    model=model,
+    optimizer=optimizer,
+    device="cuda:0",
+    use_amp=True,
+    use_wandb=True,             # log batch metrics to Weights & Biases
+    checkpoint_dir="runs/exp1", # checkpoints stored here
+    physics_regularization=True,
+    physics_lambda=0.05,
+    loss_type="huber",
+)
 
-Implementing custom training strategies:
+for epoch in range(20):
+    metrics = trainer.train_epoch(train_loader)
+    val_metrics = trainer.validate(val_loader)
+    trainer.current_epoch += 1
+    if val_metrics["val_loss"] < trainer.best_val_loss:
+        trainer.best_val_loss = val_metrics["val_loss"]
+        trainer.save_checkpoint("best.pt")
+```
 
+Reloading is as simple as `trainer.load_checkpoint("best.pt")`. If you need to
+alter the physics weighting on the fly, adjust `trainer.physics_lambda` between
+epochs.
+
+## Custom physics projections with `WeatherODESolver`
+
+When you want fine-grained control over integration and constraint enforcement,
+use `weatherflow.solvers.WeatherODESolver` directly instead of the convenience
+wrapper `WeatherFlowODE`.
+
+```python
+import numpy as np
+import torch
+from weatherflow.solvers import WeatherODESolver
+
+solver = WeatherODESolver(
+    method="rk4",
+    rtol=5e-5,
+    atol=5e-5,
+    physics_constraints=True,
+    constraint_types=["mass", "energy", "vorticity"],
+    constraint_weights={"mass": 1.0, "energy": 0.3, "vorticity": 0.2},
+    grid_spacing=(np.deg2rad(2.5), np.deg2rad(2.5)),
+)
+
+with torch.no_grad():
+    trajectory, stats = solver.solve(
+        velocity_fn=lambda x, t: model(x, t.expand(x.shape[0])),
+        x0=initial_state,
+        t_span=torch.linspace(0.0, 1.0, steps=25, device=initial_state.device),
+    )
+
+print(stats)
+```
+
+The solver tracks constraint violations and relative energy drift in `stats`.
+Use these diagnostics to tune `constraint_weights` or swap to a different
+integration scheme.
+
+## Serving interactive experiments
+
+WeatherFlow ships with a lightweight FastAPI application that generates
+synthetic datasets, trains a small `WeatherFlowMatch` model, and exposes the
+results over a REST API consumed by the React dashboard in `frontend/`.
+
+1. Start the API:
+
+   ```bash
+   uvicorn weatherflow.server.app:app --reload --port 8000
+   ```
+
+   The server exposes `/api/options` (configuration metadata) and
+   `/api/experiments` (launch a training + inference run). Internally it uses the
+   same `FlowTrainer` and solver utilities documented above.
+
+2. In another terminal, install and launch the dashboard:
+
+   ```bash
+   cd frontend
+   npm install
+   npm run dev
+   ```
+
+   Open the printed URL (usually `http://localhost:5173`) to explore the guided
+   workflow. The dashboard walks through dataset synthesis, model
+   configuration, training progress, and channel-wise trajectory visualisations.
+
+For production usage you can freeze the API responses, mount a GPU-backed model,
+or extend the schemas defined in `weatherflow/server/app.py`.
+
+## Working with notebooks and the dashboard
+
+The repository includes a helper script that provisions a notebook environment,
+installs the package in editable mode, and fixes relative imports in the bundled
+notebooks:
+
+```bash
+python setup_notebook_env.py
+```
+
+Alternatively, install the notebook requirements manually:
+
+```bash
+pip install -r notebooks/notebook_requirements.txt
+python notebooks/fix_notebook_imports.py
+```
+
+Use `check_notebooks.py` to execute and validate the notebooks inside CI. The
+`NOTEBOOK_GUIDE.md` file explains the structure and recommended workflow.
+
+## Atmospheric education and SKEW-T tooling
+
+WeatherFlow includes unique tools for teaching and visualising atmospheric
+concepts:
+
+- `weatherflow.utils.SkewTImageParser` extracts temperature/dewpoint traces from
+  SKEW-T imagery and returns thermodynamic profiles.
+- `weatherflow.utils.SkewT3DVisualizer` renders the extracted profile as an
+  interactive 3D curtain plot using Plotly.
+- `weatherflow.education.GraduateAtmosphericDynamicsTool` builds interactive
+  dashboards for geostrophic balance, Rossby-wave dispersion, and practice
+  problem generation.
+
+Example workflow:
+
+```python
+from weatherflow.utils import SkewTImageParser, SkewT3DVisualizer
+from weatherflow.education import GraduateAtmosphericDynamicsTool
+
+parser = SkewTImageParser()
+profile = parser.parse_image("data/sample_skewt.png")
+figure_path = SkewT3DVisualizer().create_and_save(profile, "skewt.html")
+
+print("3D sounding saved to", figure_path)
+
+tool = GraduateAtmosphericDynamicsTool(reference_latitude=45.0)
+rossby_fig = tool.create_rossby_wave_lab(mean_flow=20.0)
+rossby_fig.show()
+```
+
+These components are optional at runtime; install Plotly if you plan to use the
+visualisers.
+
+## Continuous integration and quality checks
+
+- Run `pytest` before pushing changes to exercise the test suite in `tests/`.
+- Apply `flake8`, `black --check`, and `isort --check-only` if you installed the
+  development extras. The project ships with a `.pre-commit-config.yaml` file so
+  you can enable automatic formatting.
+- Use `mkdocs build` (with the docs extra installed) to validate the
+  documentation renders without warnings.
+
+Combine these practices with the patterns above to move from exploratory scripts
+to reproducible experiments quickly.

--- a/docs/api/data.md
+++ b/docs/api/data.md
@@ -1,19 +1,80 @@
 # Data Loading API Reference
 
+WeatherFlow ships with dataset classes tailored for atmospheric reanalysis data
+and lightweight synthetic experiments. These utilities live in
+`weatherflow.data` and integrate seamlessly with PyTorch's `Dataset`/`DataLoader`
+API.
+
 ## ERA5Dataset
 
-::: weatherflow.data.ERA5Dataset
-    :docstring:
+`ERA5Dataset` is the primary entry point for real-world data. It can:
+
+- Stream directly from the public WeatherBench2 Google Cloud Storage bucket with
+  multiple fallback strategies (anonymous GCS, HTTPS mirror, local Zarr, NetCDF).
+- Select variables by their short names (`"t"`, `"z"`, `"u"`, `"v"`, etc.) and
+  map them to the descriptive keys used inside the dataset.
+- Slice by pressure level and time using standard Python slices or `(start, end)`
+  tuples.
+- Optionally normalise the variables using built-in statistics and enrich the
+  dataset with derived diagnostics such as wind speed and vorticity.
+- Cache samples in memory for rapid prototyping (`cache_data=True`).
+
+Typical usage:
+
+```python
+from weatherflow.data import ERA5Dataset
+
+dataset = ERA5Dataset(
+    variables=["z", "t"],
+    pressure_levels=[500],
+    time_slice=("2015", "2015"),
+    normalize=True,
+    add_physics_features=True,
+)
+
+sample = dataset[0]
+print(sample["input"].shape, sample["metadata"])
+```
+
+::: weatherflow.data.era5.ERA5Dataset
     :members:
+    :show-inheritance:
 
 ## WeatherDataset
 
-::: weatherflow.data.WeatherDataset
-    :docstring:
+`WeatherDataset` provides a minimal interface for loading local HDF5 archives
+containing variables such as geopotential height or temperature. It is useful
+for unit tests and small offline experiments.
+
+::: weatherflow.data.datasets.WeatherDataset
     :members:
 
-## Data Utilities
+## Data loader helper
 
-::: weatherflow.data.transforms
-    :docstring:
-    :members:
+`create_data_loaders` spins up train/validation datasets with consistent
+configuration and wraps them in PyTorch `DataLoader` instances. It accepts the
+same keyword arguments as `ERA5Dataset` plus `batch_size`/`num_workers`.
+
+```python
+from weatherflow.data import create_data_loaders
+
+train_loader, val_loader = create_data_loaders(
+    variables=["z", "t"],
+    pressure_levels=[500],
+    train_slice=("2015", "2015"),
+    val_slice=("2016", "2016"),
+    batch_size=16,
+    num_workers=4,
+)
+```
+
+::: weatherflow.data.era5.create_data_loaders
+
+## Tips
+
+- Inspect `dataset.shape` to discover the `(variables, levels, lat, lon)` layout
+  before configuring your model.
+- Use `dataset.get_coords()` to retrieve the latitude/longitude grids for
+  plotting.
+- When working offline, set `data_path` to a local Zarr or NetCDF archive to skip
+  network access entirely.

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -1,25 +1,67 @@
 # Models API Reference
 
-## PhysicsGuidedAttention
+WeatherFlow provides several neural architectures for flow matching and related
+modelling tasks. All models are implemented with PyTorch and expose familiar
+`forward(...)` methods.
 
-::: weatherflow.models.PhysicsGuidedAttention
-    :docstring:
+## Flow matching networks
+
+`WeatherFlowMatch` is the flagship architecture used throughout the examples. It
+produces a velocity field conditioned on the current state and a scalar time. A
+companion class `WeatherFlowODE` wraps a trained flow model and integrates it
+with `torchdiffeq`.
+
+::: weatherflow.models.flow_matching.WeatherFlowMatch
+    :members:
+    :show-inheritance:
+
+::: weatherflow.models.flow_matching.WeatherFlowODE
     :members:
 
-## StochasticFlowModel
+::: weatherflow.models.flow_matching.ConvNextBlock
+    :members:
+    :show-inheritance:
 
-::: weatherflow.models.StochasticFlowModel
-    :docstring:
+## Physics-guided attention baseline
+
+`PhysicsGuidedAttention` offers a compact residual architecture with channel
+attention, sinusoidal time embeddings, and energy normalisation. It is useful
+for unit tests and quick experiments.
+
+::: weatherflow.models.physics_guided.PhysicsGuidedAttention
     :members:
 
-## WeatherFlowPath
+## Stochastic flow surrogate
 
-::: weatherflow.models.WeatherFlowPath
-    :docstring:
+`StochasticFlowModel` approximates a stochastic flow while still satisfying the
+`BaseWeatherModel` constraints. It includes explicit implementations of mass and
+energy conservation penalties.
+
+::: weatherflow.models.stochastic.StochasticFlowModel
+    :members:
+    :show-inheritance:
+
+## Dense neural ODE model
+
+`WeatherFlowModel` couples a learned velocity network with the general-purpose
+`WeatherODESolver` and the spherical manifold utilities. It serves as a template
+for building denser models that operate on flattened grids.
+
+::: weatherflow.models.weather_flow.WeatherFlowModel
     :members:
 
-## Training
+## Base classes and score utilities
 
-::: weatherflow.models.WeatherTrainer
-    :docstring:
+The base class defines the physics-aware interface shared by multiple models.
+Score-matching helpers make it easy to interoperate with diffusion techniques.
+
+::: weatherflow.models.base.BaseWeatherModel
     :members:
+    :show-inheritance:
+
+::: weatherflow.models.score_matching.ScoreMatchingModel
+    :members:
+
+::: weatherflow.models.conversion.vector_field_to_score
+
+::: weatherflow.models.conversion.score_to_vector_field

--- a/docs/api/solvers.md
+++ b/docs/api/solvers.md
@@ -1,0 +1,25 @@
+# Solvers and Probability Paths
+
+These utilities bridge trained velocity fields with numerical integrators and
+provide reusable probability paths for score/flow conversions.
+
+## Probability path abstractions
+
+::: weatherflow.path.prob_path.ProbPath
+    :members:
+    :show-inheritance:
+
+::: weatherflow.path.gaussian_path.GaussianProbPath
+    :members:
+
+::: weatherflow.path.condot_path.CondOTPath
+    :members:
+
+## WeatherODESolver
+
+`WeatherODESolver` integrates a velocity field while enforcing optional mass,
+energy, and vorticity constraints. It is a lower-level alternative to
+`WeatherFlowODE` with detailed diagnostics and control over the numerical method.
+
+::: weatherflow.solvers.ode_solver.WeatherODESolver
+    :members:

--- a/docs/api/training.md
+++ b/docs/api/training.md
@@ -1,0 +1,30 @@
+# Training API Reference
+
+`weatherflow.training.flow_trainer` contains utilities for fitting flow-matching
+models. The main components are the `FlowTrainer` class and the functional
+`compute_flow_loss` helper.
+
+## FlowTrainer
+
+`FlowTrainer` encapsulates a full PyTorch training loop with support for:
+
+- Mixed-precision training (AMP) when running on CUDA.
+- Physics regularisation via `model.compute_physics_loss`.
+- Optional Weights & Biases logging.
+- Checkpoint management (save/load) and scheduler hooks.
+
+Instantiate it with your model and optimizer, then call `train_epoch` and
+`validate` with PyTorch data loaders. The class tracks average metrics and keeps
+`best_val_loss` up to date.
+
+::: weatherflow.training.flow_trainer.FlowTrainer
+    :members:
+    :show-inheritance:
+
+## compute_flow_loss
+
+Computes the target velocity and compares it against the model's prediction
+using MSE, Huber, or Smooth-L1 loss. It is exposed separately so you can plug it
+into custom training loops or perform manual gradient computations.
+
+::: weatherflow.training.flow_trainer.compute_flow_loss

--- a/docs/api/visualization.md
+++ b/docs/api/visualization.md
@@ -1,18 +1,51 @@
-# Visualization API Reference
+# Utilities and Visualization API Reference
+
+WeatherFlow bundles a range of utilities for interpreting model outputs,
+creating publication-ready figures, and teaching atmospheric dynamics.
 
 ## WeatherVisualizer
 
-::: weatherflow.utils.WeatherVisualizer
-    :docstring:
+Map-focused plotting powered by Matplotlib and Cartopy. Supports global fields,
+comparison plots, error distributions, animations, and flow vector overlays.
+
+::: weatherflow.utils.visualization.WeatherVisualizer
     :members:
 
-### Plot Types
+## FlowVisualizer
 
-- `plot_prediction_comparison`: Compare true and predicted states
-- `plot_error_distribution`: Analyze prediction errors
-- `plot_global_forecast`: Display global weather patterns
-- `plot_time_series`: Show temporal evolution
-- `create_animation`: Animate prediction sequences
+Simple helper for animating the evolution of a state along the learned flow. It
+is useful for debugging training runs without leaving the notebook.
 
-### Examples
+::: weatherflow.utils.flow_visualization.FlowVisualizer
+    :members:
 
+## SKEW-T parsing and 3D visualisation
+
+Turn static sounding images into quantitative profiles and interactive Plotly
+figures.
+
+::: weatherflow.utils.skewt.SkewTImageParser
+    :members:
+
+::: weatherflow.utils.skewt.SkewT3DVisualizer
+    :members:
+
+::: weatherflow.utils.skewt.SkewTCalibration
+    :members:
+
+::: weatherflow.utils.skewt.RGBThreshold
+    :members:
+
+## Educational dashboard
+
+Generate geostrophic balance dashboards, Rossby wave laboratories, and worked
+practice problems for classroom use.
+
+::: weatherflow.education.graduate_tool.GraduateAtmosphericDynamicsTool
+    :members:
+
+::: weatherflow.education.graduate_tool.ProblemScenario
+    :members:
+
+::: weatherflow.education.graduate_tool.SolutionStep
+    :members:

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,26 +1,34 @@
-# API Reference
+# API Reference Overview
 
-## Models
+The WeatherFlow package exposes a cohesive API organised around the workflow of
+loading data, fitting a flow model, integrating trajectories, and presenting the
+results. The following pages document each subsystem in detail:
 
-### PhysicsGuidedAttention
+- [Data Loading](api/data.md) – `ERA5Dataset`, `WeatherDataset`,
+  `create_data_loaders`, and dataset utilities.
+- [Models](api/models.md) – flow-matching networks, physics-guided baselines,
+  score-matching helpers, and conversion utilities.
+- [Training](api/training.md) – the `FlowTrainer` class, `compute_flow_loss`, and
+  checkpoint helpers.
+- [Solvers and Paths](api/solvers.md) – probability paths (`ProbPath`,
+  `GaussianProbPath`, `CondOTPath`) and the `WeatherODESolver` integration
+  toolkit.
+- [Utilities and Visualization](api/visualization.md) – map plotting,
+  flow-trajectory inspectors, SKEW-T tooling, and the educational dashboard
+  helpers.
 
-Physics-informed attention model for weather prediction.
+The package root (`weatherflow/__init__.py`) re-exports the most common symbols
+so you can do:
 
+```python
+from weatherflow import (
+    ERA5Dataset,
+    WeatherFlowMatch,
+    WeatherFlowODE,
+    FlowTrainer,
+    WeatherVisualizer,
+)
+```
 
-### StochasticFlowModel
-
-Stochastic flow-based weather prediction model.
-
-
-## Data Loading
-
-### ERA5Dataset
-
-
-### WeatherDataset
-
-
-## Visualization
-
-### WeatherVisualizer
-
+Refer back to this page whenever you need to locate a specific class; each entry
+links to the module containing the implementation and docstring.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,51 @@
+# Examples
+
+The `examples/` directory contains runnable scripts and notebooks that
+demonstrate the library in action. Use them as templates for your own projects or
+as quick regression tests when upgrading dependencies.
+
+## `weather_prediction.py`
+
+End-to-end ERA5 flow-matching pipeline that covers:
+
+1. Loading data with `create_data_loaders`.
+2. Configuring `WeatherFlowMatch` (with optional attention/physics flags).
+3. Training with Adam and a ReduceLROnPlateau scheduler.
+4. Saving checkpoints, metrics, and generated predictions.
+5. Plotting geopotential height comparisons and error maps.
+
+Run it with:
+
+```bash
+python examples/weather_prediction.py --variables z t --pressure-levels 500 \
+    --train-years 2015 2016 --val-years 2017 --epochs 10 --use-attention \
+    --physics-informed --save-model --save-results
+```
+
+The script writes outputs under `results/<timestamp>/` and logs metrics to the
+console.
+
+## `flow_matching/simple_example.py`
+
+Minimal synthetic demonstration that trains a small `WeatherFlowMatch` on random
+data. It is ideal for debugging custom layers or verifying new environments can
+load PyTorch + TorchDiffEq correctly.
+
+## `skewt_3d_visualizer.py`
+
+Shows how to parse a SKEW-T sounding image with `SkewTImageParser` and render an
+interactive 3D curtain plot using `SkewT3DVisualizer`. The resulting HTML file
+opens in any browser and is perfect for presentations.
+
+## `visualization_examples.ipynb`
+
+Notebook gallery of map and animation utilities powered by `WeatherVisualizer`
+and `FlowVisualizer`. Launch it through Jupyter after running
+`python setup_notebook_env.py`.
+
+## Tips
+
+- Pass `--help` to any script to view the supported command-line arguments.
+- Copy the scripts into your own project and swap in custom datasets or models.
+- Pair the scripts with [Advanced Usage](advanced_usage.md) to integrate them
+  into automated pipelines or the FastAPI dashboard.

--- a/docs/flow_matching.md
+++ b/docs/flow_matching.md
@@ -1,28 +1,104 @@
 # Flow Matching and Diffusion Models
 
-This module implements flow matching and diffusion models based on MIT lecture notes on Flow Matching and Diffusion Models.
+WeatherFlow implements continuous flow matching as described in recent neural ODE
+and diffusion literature. This page summarises how the components in the
+repository map onto the theory so you know where to look when extending the
+library.
 
-## Components
+## Probability paths
 
-### Path Module
+Flow matching starts by defining a probability path \(p_t(x)\) that bridges a
+simple reference distribution to the data distribution. WeatherFlow provides a
+compact hierarchy of path classes in `weatherflow.path`:
 
-- `GaussianProbPath`: Implements Gaussian conditional probability paths with customizable schedules
-- `CondOTPath`: Implements Conditional Optimal Transport paths (a special case of Gaussian paths)
+- [`ProbPath`](../weatherflow/path/prob_path.py) – abstract base class defining
+  `sample_path(...)` and `get_flow_vector(...)`.
+- [`GaussianProbPath`](../weatherflow/path/gaussian_path.py) – implements the
+  conditional Gaussian path \(p_t(x \mid z) = \mathcal{N}(\alpha_t z, \beta_t^2 I)\)
+  with helper methods to compute the analytic score and vector field.
+- `CondOTPath` – a thin wrapper for conditional optimal transport schedules.
 
-### Models Module
+Use these classes when you need analytic reference paths or to convert between
+vector-field and score-based parameterisations.
 
-- `ScoreMatchingModel`: Implements score matching for diffusion models
-- Conversion utilities between vector fields and score functions
+## Vector-field models
 
-### Solvers Module
+The default flow-matching network is [`WeatherFlowMatch`](../weatherflow/models/flow_matching.py),
+a ConvNeXt-inspired architecture with sinusoidal time embeddings, optional
+multi-head attention, and an approximate divergence projection. It exposes
+`forward(x, t)` returning the velocity field \(u_t(x)\) and
+`compute_flow_loss(x0, x1, t)` for convenience.
 
-- `langevin_dynamics`: Implements Langevin dynamics sampling
-- Enhanced ODE solvers with Heun's method and ODE-to-SDE conversion
+Other models in `weatherflow.models` include:
 
-### Training Module
+- [`PhysicsGuidedAttention`](../weatherflow/models/physics_guided.py) – a compact
+  baseline with channel attention and energy normalisation.
+- [`StochasticFlowModel`](../weatherflow/models/stochastic.py) – a residual
+  architecture that approximates stochastic drift and provides explicit mass and
+  energy constraint terms.
+- [`ScoreMatchingModel`](../weatherflow/models/score_matching.py) – learns the
+  score \(\nabla_x \log p_t(x)\) for a supplied probability path.
+- Conversion utilities [`vector_field_to_score`](../weatherflow/models/conversion.py)
+  and [`score_to_vector_field`](../weatherflow/models/conversion.py) implement the
+  relationships described in the lecture notes (Eq. 54–55).
 
-- `FlowMatchTrainer`: Implements training for flow matching models
+## Training objective
 
-## Usage Examples
+The loss is the squared error between the predicted velocity and the straight
+line connecting the source and target samples:
 
-See the examples directory for usage examples.
+```python
+from weatherflow.training.flow_trainer import compute_flow_loss
+
+loss = compute_flow_loss(v_t, x0, x1, t, loss_type="mse")
+```
+
+`FlowTrainer` wraps this computation in a full training loop with optional
+physics regularisation (`model.compute_physics_loss`) and mixed precision. You
+can combine it with Weights & Biases logging, schedulers, or your own training
+scripts as shown in the [Getting Started guide](getting_started.md).
+
+## Integrating trajectories
+
+To turn the learned velocity field into forecasts, integrate the ODE using one
+of the solver utilities:
+
+- [`WeatherFlowODE`](../weatherflow/models/flow_matching.py) – minimal wrapper
+  that calls the flow model inside `torchdiffeq.odeint`.
+- [`WeatherODESolver`](../weatherflow/solvers/ode_solver.py) – richer solver with
+  constraint tracking, energy conservation monitoring, and configurable
+  integration schemes.
+
+Example:
+
+```python
+from weatherflow.models.flow_matching import WeatherFlowODE
+
+ode_model = WeatherFlowODE(flow_model, solver_method="dopri5")
+trajectory = ode_model(initial_state, torch.linspace(0.0, 1.0, 11))
+```
+
+## Putting it together
+
+A minimal training loop looks like:
+
+```python
+import torch
+
+for batch in train_loader:
+    x0, x1 = batch["input"].to(device), batch["target"].to(device)
+    t = torch.rand(x0.size(0), device=device)
+    v_t = model(x0, t)
+    losses = model.compute_flow_loss(x0, x1, t)
+    optimizer.zero_grad()
+    losses["total_loss"].backward()
+    optimizer.step()
+```
+
+For more elaborate workflows, study `examples/weather_prediction.py` and the API
+reference pages linked above. The
+[Continuous Normalizing Flows note](advanced_topics/continuous_normalizing_flows.md)
+contains additional theory, while the
+[Flow Matching Implementation guide](advanced_topics/flow_matching_implementation.md)
+explains how the spherical manifold and probability paths interact with the
+solvers.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,15 +1,163 @@
 # Getting Started with WeatherFlow
 
-## Installation
+This guide walks through the quickest route from a fresh clone of the
+repository to training and evaluating a small flow-matching model. It assumes
+you have already followed the [installation steps](installation.md) and have an
+active virtual environment.
 
+## 1. Import the package and check the version
 
-## Quick Start
+```python
+import weatherflow
+print(weatherflow.__version__)
+```
 
+The package exposes high-level entry points from `weatherflow.__init__` so that
+you can import the most common classes from the top level:
 
-## Core Features
+```python
+from weatherflow.data import create_data_loaders
+from weatherflow.models import WeatherFlowMatch
+from weatherflow.models.flow_matching import WeatherFlowODE
+from weatherflow.training.flow_trainer import FlowTrainer
+from weatherflow.utils import WeatherVisualizer
+```
 
-- Physics-guided attention for weather prediction
-- Stochastic flow modeling
-- Built-in ERA5 data support
-- Comprehensive visualization tools
-- Physics-constrained predictions
+## 2. Load ERA5 samples
+
+The `ERA5Dataset` streams slices of reanalysis data either from the public
+WeatherBench2 bucket or from a local archive. The helper
+`create_data_loaders(...)` instantiates train/validation datasets and wraps them
+in PyTorch data loaders with sensible defaults.
+
+```python
+from weatherflow.data import create_data_loaders
+
+train_loader, val_loader = create_data_loaders(
+    variables=["z", "t"],          # geopotential height and temperature
+    pressure_levels=[500],         # hPa levels to include
+    train_slice=("2015", "2015"),  # inclusive date range
+    val_slice=("2016", "2016"),
+    batch_size=4,                  # keep tiny while exploring
+    num_workers=0,                 # use >0 once the dataset is cached
+    normalize=True,                # standardises using built-in statistics
+)
+
+sample = next(iter(train_loader))
+print(sample["input"].shape)      # (batch, variables, levels, lat, lon)
+print(sample["metadata"])
+```
+
+Key dataset features:
+
+- Automatic fallback between anonymous GCS access, HTTP mirrors, local Zarr, and
+  NetCDF files.
+- Optional derived diagnostics (wind speed, vorticity) via
+  `ERA5Dataset(..., add_physics_features=True)`.
+- In-memory caching with `cache_data=True` for small experiments.
+
+## 3. Configure a flow-matching model
+
+`WeatherFlowMatch` implements the velocity field used for flow matching. The
+architecture combines convolutional blocks, sinusoidal time embeddings, and an
+optional multi-head attention layer. You can enable a lightweight physics
+projection that nudges the vector field toward divergence-free behaviour.
+
+```python
+from weatherflow.models import WeatherFlowMatch
+
+model = WeatherFlowMatch(
+    input_channels=sample["input"].shape[1],
+    hidden_dim=128,
+    n_layers=4,
+    use_attention=True,
+    physics_informed=True,
+)
+```
+
+If you want an even smaller baseline, experiment with
+`weatherflow.models.PhysicsGuidedAttention` or
+`weatherflow.models.StochasticFlowModel`.
+
+## 4. Train with `FlowTrainer`
+
+`FlowTrainer` wraps a model, optimizer, and optional scheduler/regularisation
+settings. It handles mixed-precision, physics-aware penalties, and checkpointing.
+
+```python
+import torch
+from weatherflow.training.flow_trainer import FlowTrainer, compute_flow_loss
+
+optimizer = torch.optim.Adam(model.parameters(), lr=1e-4)
+trainer = FlowTrainer(
+    model=model,
+    optimizer=optimizer,
+    device="cuda" if torch.cuda.is_available() else "cpu",
+    physics_regularization=True,
+    physics_lambda=0.1,
+)
+
+for epoch in range(2):
+    metrics = trainer.train_epoch(train_loader)
+    val_metrics = trainer.validate(val_loader)
+    print(f"Epoch {epoch}: {metrics['loss']:.4f} | val {val_metrics['val_loss']:.4f}")
+```
+
+Behind the scenes, each iteration draws random interpolation times `t`, calls
+`model(x0, t)` to obtain the predicted velocity, and compares it against the
+straight-line target `(x1 - x0)/(1 - t)` computed by `compute_flow_loss`.
+
+> **Tip:** You can enable Weights & Biases logging by instantiating the trainer
+> with `use_wandb=True` after configuring your `wandb` credentials.
+
+## 5. Generate forecasts with `WeatherFlowODE`
+
+Once the flow model converges, wrap it with `WeatherFlowODE` to integrate the
+state forward in time using `torchdiffeq`.
+
+```python
+from weatherflow.models.flow_matching import WeatherFlowODE
+
+ode_model = WeatherFlowODE(model, solver_method="dopri5", rtol=1e-4, atol=1e-4)
+
+with torch.no_grad():
+    batch = next(iter(val_loader))["input"].to(trainer.device)
+    times = torch.linspace(0.0, 1.0, steps=5, device=trainer.device)
+    trajectory = ode_model(batch, times)
+```
+
+`trajectory` has shape `(num_times, batch, channels, lat, lon)` and can be fed
+into the visualisation utilities or custom diagnostics.
+
+## 6. Visualise predictions
+
+The `WeatherVisualizer` class renders global maps, comparisons, and animations
+without leaving Matplotlib and Cartopy.
+
+```python
+from weatherflow.utils import WeatherVisualizer
+
+visualizer = WeatherVisualizer()
+visualizer.plot_comparison(
+    true_data={"z": batch[0, 0].cpu()},
+    pred_data={"z": trajectory[-1, 0, 0].cpu()},
+    var_name="z",
+    title="Geopotential Height – Forecast vs Truth",
+)
+```
+
+For flow-specific insight, `weatherflow.utils.FlowVisualizer` animates how the
+state evolves along the learned velocity field. If you have sounding imagery,
+`weatherflow.utils.SkewTImageParser` and `SkewT3DVisualizer` can turn it into an
+interactive 3D curtain plot.
+
+## 7. Next steps
+
+- Explore the [Quick Start tutorial](tutorials/quickstart.md) for a fully worked
+  example with command-line arguments and disk outputs.
+- Read the [ERA5 tutorial](tutorials/era5.md) to customise data access, derived
+  fields, and caching strategies.
+- Dive into [Advanced Usage](advanced_usage.md) for notebooks, the FastAPI
+  dashboard, and deployment considerations.
+- Check the [API reference](api/data.md) when you need the full signature of any
+  class or function.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,15 +1,95 @@
 # WeatherFlow
 
-A Python library for flow-based weather prediction with physics constraints.
+WeatherFlow is a research-friendly Python library for building flow-matching
+weather models that respect atmospheric physics. It wraps PyTorch modules for
+vector-field learning, spherical geometry utilities, probabilistic paths, and a
+set of visualization and education tools that make it easy to prototype new
+ideas or reproduce the examples that ship with the repository.
 
-## Key Features
+## What makes WeatherFlow different?
 
-- Physics-guided attention models
-- Stochastic flow predictions
-- Weather path modeling
-- ERA5 data integration
-- Built-in visualization tools
+WeatherFlow collects everything you need for a flow-matching weather workflow in
+one place:
 
-## Why WeatherFlow?
+- **Rich data loaders** that can stream ERA5 reanalysis data directly from the
+  WeatherBench2 bucket, open local NetCDF/Zarr archives, and optionally add
+  derived diagnostics such as wind speed and vorticity.
+- **Model zoo for experimentation**, including the `WeatherFlowMatch` flow
+  network, physics-guided attention baselines, stochastic surrogates, and dense
+  neural ODE formulations.
+- **Training and solver utilities** that understand flow-matching loss
+  functions, mixed precision, physics regularisation, and ODE-based inference.
+- **Visualisation and education helpers** for publishing maps, animations, and
+  interactive graduate-level atmospheric dynamics dashboards.
+- **FastAPI + React dashboard** that lets new users explore a synthetic
+  workflow end-to-end without writing code.
 
-WeatherFlow combines modern deep learning techniques with physical constraints to create accurate and physically consistent weather predictions.
+Whether you are validating a paper idea or want a turnkey demo, the library is
+organised so you can start from a minimal script and scale to complex
+experiments without rewriting core infrastructure.
+
+## How to use this documentation
+
+The documentation mirrors the stages of a typical project:
+
+1. [Installation](installation.md) explains how to set up a working Python
+   environment (with optional extras for docs, notebooks, and linting).
+2. [Getting Started](getting_started.md) walks through loading ERA5 data,
+   training `WeatherFlowMatch`, producing forecasts with `WeatherFlowODE`, and
+   creating quick diagnostics.
+3. [Tutorials](tutorials/quickstart.md) dive deeper into common tasks such as
+   manipulating ERA5 archives or configuring custom physics constraints.
+4. [Advanced Usage](advanced_usage.md) covers topics like the interactive API,
+   notebook tooling, SKEW-T parsing, and production check-pointing.
+5. [API Reference](api/data.md) documents the public Python surfaces organised
+   by domain (data, models, training, solvers, utilities).
+6. [Advanced Topics](advanced_topics/continuous_normalizing_flows.md) collects
+   background notes on continuous normalising flows and WeatherFlow's specific
+   implementation choices.
+
+Each page links back to the relevant modules and examples so you can jump from
+concepts to runnable code quickly.
+
+## Repository layout
+
+The repository is split into a few key directories:
+
+| Location | Description |
+| --- | --- |
+| `weatherflow/` | Python package containing data loaders, models, solvers, training loops, and utilities. |
+| `examples/` | End-to-end scripts (ERA5 flow-matching, SKEW-T visualisation, minimal flow examples). |
+| `docs/` | MkDocs source for this documentation site. |
+| `notebooks/` | Jupyter notebooks illustrating the concepts in narrative form. |
+| `frontend/` | Vite/React dashboard that speaks to the FastAPI service defined in `weatherflow/server`. |
+| `tests/` | Pytest suite and utilities for regression testing. |
+
+See [Advanced Usage](advanced_usage.md#working-with-notebooks-and-the-dashboard)
+for tips on setting up the dashboard and notebook environment.
+
+## Typical workflow
+
+A flow-matching experiment with WeatherFlow usually follows these steps:
+
+1. **Prepare data** – load ERA5 slices with `ERA5Dataset` or synthetic data from
+   the FastAPI service, optionally enabling normalisation or derived fields.
+2. **Configure a model** – start with `WeatherFlowMatch` for flow matching or
+   `PhysicsGuidedAttention`/`StochasticFlowModel` for lighter baselines.
+3. **Train** – use `FlowTrainer` or the scripted examples to optimise the model
+   with physics-aware loss terms and mixed precision.
+4. **Integrate trajectories** – wrap the trained flow with `WeatherFlowODE` or
+   call `WeatherODESolver` directly to evolve the state through time.
+5. **Evaluate and visualise** – quantify skill, render maps with
+   `WeatherVisualizer`, and export animations or 3D soundings.
+6. **Deploy or share** – expose the model through the FastAPI interface or the
+   notebook gallery for interactive exploration.
+
+Refer to the [Quick Start tutorial](tutorials/quickstart.md) for a runnable
+version of this workflow.
+
+## Where to go next
+
+If you are new to the project, install the dependencies and run through the
+[Quick Start tutorial](tutorials/quickstart.md). Users interested in the theory
+can review the [Flow Matching Primer](flow_matching.md), while advanced users
+can jump straight to the [API reference](api/data.md) to integrate WeatherFlow
+into their own pipelines.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,13 +1,108 @@
 # Installation
 
-## Using pip
+WeatherFlow targets Python 3.8+ and PyTorch 2.x. The quickest way to get
+started is to create an isolated environment, install the package in editable
+mode, and pull in the optional extras that match your workflow.
 
+## 1. Prerequisites
 
-## Dependencies
+- Python 3.8 or newer (3.10/3.11 recommended).
+- A recent PyTorch build with CUDA if you plan to train on the GPU. The examples
+  default to CPU when CUDA is not available.
+- Cartopy, PROJ, and GEOS system libraries are required for the map plotting
+  utilities. On Ubuntu/Debian you can install them with:
 
-WeatherFlow requires:
-- Python ≥ 3.8
-- PyTorch ≥ 1.9
-- NumPy ≥ 1.20
-- Matplotlib ≥ 3.4
-- Cartopy ≥ 0.21
+  ```bash
+  sudo apt-get install libproj-dev proj-data proj-bin libgeos-dev
+  ```
+
+- Optional but recommended: `conda` or `python -m venv` for environment
+  management.
+
+## 2. Create a virtual environment
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # On Windows use `.venv\Scripts\activate`
+python -m pip install --upgrade pip
+```
+
+You can substitute `conda create -n weatherflow python=3.10` if you prefer the
+Conda stack.
+
+## 3. Install WeatherFlow from source
+
+Clone the repository and install it in editable mode so that local changes are
+immediately reflected when you run the examples:
+
+```bash
+git clone https://github.com/monksealseal/weatherflow.git
+cd weatherflow
+pip install -e .
+```
+
+This pulls in the core runtime dependencies declared in `pyproject.toml`,
+including PyTorch, xarray, TorchDiffEq, FastAPI, and the plotting stack.
+
+### Optional extras
+
+Install the optional dependency groups when you need them:
+
+| Extra | Command | Purpose |
+| --- | --- | --- |
+| Development | `pip install -e .[dev]` | Installs pytest, coverage, Black, isort, flake8, and mypy. |
+| Documentation | `pip install -e .[docs]` | Brings in `mkdocs-material` and `mkdocstrings` for building this documentation site. |
+| Notebooks | `python setup_notebook_env.py` | Creates a ready-to-use notebook environment with WeatherFlow pre-installed. |
+
+You can combine extras, e.g. `pip install -e .[dev,docs]`.
+
+## 4. Configure access to ERA5/WeatherBench2
+
+The default `ERA5Dataset` streams data from the public WeatherBench2 bucket
+(`gs://weatherbench2/...`). Anonymous GCS access works out of the box on most
+networks. If you need to route through a proxy or provide explicit credentials,
+set the environment variables consumed by `gcsfs`, for example:
+
+```bash
+export HTTPS_PROXY=http://proxy.example.com:8080
+export GCSFS_TOKEN="~/.config/gcloud/application_default_credentials.json"
+```
+
+Alternatively, download the data locally and point the dataset at the NetCDF or
+Zarr archive via the `data_path` argument.
+
+## 5. Verify the installation
+
+Run a quick import test and the unit suite to make sure everything works in your
+environment:
+
+```bash
+python - <<'PY'
+import weatherflow
+print("WeatherFlow version", weatherflow.__version__)
+PY
+
+pytest
+```
+
+The tests exercise the lightweight synthetic data loaders and model components,
+so they finish quickly even on CPU-only machines.
+
+## 6. Troubleshooting
+
+- **Cartopy import errors** – ensure the PROJ and GEOS libraries are installed
+  system-wide before installing WeatherFlow. Reinstall `cartopy` after the
+  libraries are present.
+- **`torchdiffeq` missing** – the ODE-based components depend on
+  `torchdiffeq>=0.2.3`. It is installed automatically via the package metadata,
+  but double-check with `pip show torchdiffeq` if you see import errors.
+- **GCS access timeouts** – the dataset tries several access strategies in
+  sequence. If you are behind a firewall, set `data_path` to a local file to
+  avoid repeated retries.
+- **Plotly optional dependencies** – modules such as the educational dashboard
+  and SKEW-T visualiser require Plotly. The base package already depends on
+  `plotly>=5.18.0`; if you trimmed dependencies manually, reinstall with the
+  default extras.
+
+With the environment ready, continue to the
+[Getting Started guide](getting_started.md) for a runnable walkthrough.

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,0 +1,35 @@
+# Release Notes
+
+This page highlights notable changes in the WeatherFlow codebase. For the full
+commit history see [`RELEASE_NOTES.md`](../RELEASE_NOTES.md).
+
+## v0.4.1 (current)
+
+- **Robust ERA5 loader** – `ERA5Dataset` now cycles through anonymous GCS,
+  HTTPS, local Zarr, and NetCDF strategies with detailed logging and optional
+  caching/derived diagnostics.
+- **FlowTrainer upgrades** – mixed precision by default on CUDA, configurable
+  loss surfaces (`mse`, `huber`, `smooth_l1`), physics regularisation hooks, and
+  integrated checkpoint management.
+- **Physics-aware ODE solver** – `WeatherODESolver` enforces mass, energy, and
+  vorticity constraints while reporting violation statistics for each
+  integration.
+- **Interactive stack** – FastAPI service (`weatherflow.server.app`) and the
+  accompanying React dashboard guide users through configuring datasets, models,
+  and training runs without code.
+- **Atmospheric education toolkit** – `GraduateAtmosphericDynamicsTool` ships
+  with geostrophic balance dashboards, Rossby-wave laboratories, and step-by-step
+  practice problems.
+- **SKEW-T parsing and 3D rendering** – convert sounding imagery to quantitative
+  profiles and interactive Plotly visualisations with
+  `SkewTImageParser`/`SkewT3DVisualizer`.
+
+## Earlier releases
+
+- **v0.1.x** – initial publication featuring the first versions of
+  `PhysicsGuidedAttention`, `StochasticFlowModel`, ERA5 data loaders, and the
+  Matplotlib-based `WeatherVisualizer`.
+
+We follow semantic versioning; expect breaking API changes only on major version
+bumps. Each tagged release is accompanied by a git tag and matching entry in the
+root `RELEASE_NOTES.md` file.

--- a/docs/tutorials/era5.md
+++ b/docs/tutorials/era5.md
@@ -1,13 +1,122 @@
 # Working with ERA5 Data
 
-## Loading ERA5 Data
+`weatherflow.data.ERA5Dataset` is designed to make ERA5 ingestion painless.
+Whether you are streaming from the public WeatherBench2 bucket or loading
+pre-downloaded archives, the class handles the mechanics for you. This tutorial
+covers the most common scenarios.
 
+## 1. Stream directly from WeatherBench2
 
-## Data Processing
+The dataset defaults to the WeatherBench2 Google Cloud Storage bucket and tries
+several access strategies in order:
 
-- Automatic handling of different variables
-- Built-in normalization
-- Proper coordinate handling
+1. Anonymous `xr.open_zarr` access.
+2. HTTPS mirror via `fsspec.filesystem("http")`.
+3. Anonymous `gcsfs` client.
+4. Local NetCDF fallback.
+5. Local Zarr fallback.
 
-## Example Workflow
+In most environments you can instantiate the loader without any additional
+configuration:
 
+```python
+from weatherflow.data import ERA5Dataset
+
+dataset = ERA5Dataset(
+    variables=["z", "t", "u", "v"],
+    pressure_levels=[850, 500, 250],
+    time_slice=("2015", "2016"),
+    normalize=True,
+)
+print(len(dataset), dataset.shape)
+```
+
+Set `verbose=True` to log each attempted access method and the outcome.
+
+## 2. Use local NetCDF or Zarr archives
+
+If you already have the ERA5 subset on disk, point `data_path` at the archive.
+The loader automatically chooses the appropriate backend based on the extension.
+
+```python
+dataset = ERA5Dataset(
+    data_path="/data/era5/geopotential_temperature.nc",
+    variables=["z", "t"],
+    pressure_levels=[500],
+    time_slice=("2015-01-01", "2015-03-31"),
+)
+```
+
+For Zarr stores, pass the directory path. WeatherFlow preserves the same
+interface regardless of the storage backend.
+
+## 3. Derived diagnostics and normalisation
+
+Enable `add_physics_features=True` to augment the dataset with derived fields
+when wind components are present:
+
+- `wind_speed` computed from the \(u\) and \(v\) components.
+- `vorticity` estimated via central differences when latitude/longitude grids are
+  available.
+
+Normalisation uses the statistics defined in `NORMALIZE_STATS`. You can disable
+it for raw values with `normalize=False` or supply custom scaling by wrapping the
+returned tensors in your own transform.
+
+## 4. Caching for faster experiments
+
+Set `cache_data=True` to keep retrieved samples in memory. This is useful for
+small experiments or unit tests where the dataset fits in RAM. The cache is keyed
+by sample index.
+
+```python
+dataset = ERA5Dataset(cache_data=True, variables=["z"], pressure_levels=[500])
+```
+
+## 5. Explore metadata and coordinates
+
+- `dataset.shape` returns `(variables, levels, lat, lon)` so you can configure the
+  model correctly.
+- `dataset.get_coords()` returns the latitude/longitude arrays and the pressure
+  levels used in the subset.
+- The `metadata` entry returned by `dataset[idx]` includes timestamps and the
+  requested variable names.
+
+```python
+sample = dataset[0]
+print(sample["metadata"]["t0"], sample["metadata"]["variables"])
+```
+
+## 6. Combine with PyTorch data loaders
+
+Use `create_data_loaders` for convenience:
+
+```python
+from weatherflow.data import create_data_loaders
+
+train_loader, val_loader = create_data_loaders(
+    variables=["z", "t"],
+    pressure_levels=[500],
+    train_slice=("2015", "2015"),
+    val_slice=("2016", "2016"),
+    batch_size=16,
+    num_workers=4,
+)
+```
+
+Adjust `num_workers` to match your storage bandwidth. When reading from local
+SSD, a handful of workers keeps the GPU busy; for remote streaming start with 0–2
+workers to avoid saturating your connection.
+
+## 7. Troubleshooting tips
+
+- **Authentication** – if anonymous GCS access is blocked, set the environment
+  variable `GCSFS_TOKEN` to point at your Google credentials JSON.
+- **Proxy support** – configure `HTTPS_PROXY`/`HTTP_PROXY` before instantiating
+  the dataset to route traffic through a proxy.
+- **Timeouts** – pass `verbose=True` to inspect the failing access method and try
+  the next one manually; often switching to a local mirror resolves the issue.
+
+With these techniques you can focus on experimenting with models instead of data
+plumbing. Continue with the [Quick Start tutorial](quickstart.md) to see the
+loader in action inside a full training script.

--- a/docs/tutorials/physics.md
+++ b/docs/tutorials/physics.md
@@ -1,0 +1,120 @@
+# Custom Physics Workflows
+
+WeatherFlow lets you combine machine learning with physically inspired
+constraints at multiple points in the pipeline. This tutorial walks through a
+few common patterns.
+
+## 1. Enable the built-in divergence projection
+
+`WeatherFlowMatch` ships with an optional physics hook that nudges the velocity
+field toward divergence-free behaviour by subtracting the gradient of the
+computed divergence from the first two channels. Activate it with
+`physics_informed=True`:
+
+```python
+from weatherflow.models import WeatherFlowMatch
+
+model = WeatherFlowMatch(
+    input_channels=4,
+    hidden_dim=192,
+    n_layers=6,
+    use_attention=True,
+    physics_informed=True,
+)
+```
+
+Inside `forward(...)` the model calls `_apply_physics_constraints` before
+returning the velocity field. You can override this method in a subclass to
+implement domain-specific corrections.
+
+## 2. Implement custom constraints
+
+To add your own projection or penalty, subclass `WeatherFlowMatch` and override
+`_apply_physics_constraints` and optionally `compute_flow_loss`:
+
+```python
+import torch
+
+class BalancedFlowMatch(WeatherFlowMatch):
+    def _apply_physics_constraints(self, v, x):
+        v = super()._apply_physics_constraints(v, x)
+        kinetic_energy = torch.sum(v**2, dim=(1, 2, 3), keepdim=True)
+        scale = torch.sqrt(torch.sum(x**2, dim=(1, 2, 3), keepdim=True) / (kinetic_energy + 1e-6))
+        return v * scale
+```
+
+Pair the model with `FlowTrainer(physics_regularization=True)` to include
+`model.compute_physics_loss` in the total loss. The base implementation computes
+mass and energy penalties; you can override it to add more terms.
+
+## 3. Use physics-aware baselines
+
+[`PhysicsGuidedAttention`](../../weatherflow/models/physics_guided.py) embeds
+physics considerations directly in the network:
+
+- Sinusoidal time embeddings allow the model to condition on forecast lead time.
+- Channel attention emphasises physically important variables.
+- Energy normalisation rescales outputs to match the input energy.
+
+Swap it in when you want a smaller model that still respects fundamental
+constraints.
+
+```python
+from weatherflow.models import PhysicsGuidedAttention
+
+model = PhysicsGuidedAttention(
+    channels=sample["input"].shape[1],
+    hidden_dim=64,
+    num_layers=4,
+    dropout=0.1,
+)
+```
+
+## 4. Configure FlowTrainer for physics-aware training
+
+`FlowTrainer` exposes two knobs for incorporating physics penalties:
+
+- `physics_regularization=True` enables the additional term.
+- `physics_lambda` controls its contribution to the total loss.
+
+```python
+import torch
+from weatherflow.training.flow_trainer import FlowTrainer
+
+trainer = FlowTrainer(
+    model=model,
+    optimizer=torch.optim.Adam(model.parameters(), lr=5e-4),
+    physics_regularization=True,
+    physics_lambda=0.2,
+)
+```
+
+Monitor `metrics["physics_loss"]` (or `"val_physics_loss"`) to gauge the
+strength of the constraint during training.
+
+## 5. Adjust constraint weights during integration
+
+When integrating trajectories, `WeatherODESolver` can enforce mass, energy, and
+vorticity constraints. Tune them per use case:
+
+```python
+from weatherflow.solvers import WeatherODESolver
+
+solver = WeatherODESolver(
+    physics_constraints=True,
+    constraint_types=["mass", "energy"],
+    constraint_weights={"mass": 1.0, "energy": 0.1},
+)
+```
+
+The returned `stats` dictionary contains average divergence and relative energy
+errors so you can adjust the weights dynamically.
+
+## 6. Next steps
+
+- Combine the techniques above with `WeatherVisualizer.plot_flow_vectors` to
+  inspect how the corrected velocity field behaves spatially.
+- Experiment with the [educational toolkit](../../weatherflow/education/graduate_tool.py)
+  to build intuition for balance constraints before embedding them in the model.
+- Review the [`WeatherODESolver` API](../api/solvers.md) for the full list of
+  supported constraint types and solver options.

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -1,2 +1,158 @@
-# Quick Start
+# Quick Start Tutorial
 
+This tutorial replicates the workflow demonstrated in `examples/weather_prediction.py`
+and breaks it down into digestible steps. By the end you will have trained a small
+flow-matching model on ERA5 data, generated a short forecast trajectory, and
+rendered diagnostic plots.
+
+## Prerequisites
+
+- Follow the [installation guide](../installation.md) to create a virtual
+  environment and install WeatherFlow with the required extras.
+- Ensure you can import the package: `python -c "import weatherflow"`.
+- Optional: install the development extras (`pip install -e .[dev]`) so you can
+  run the pytest suite.
+
+## 1. Configure data access
+
+Create a Python file `quickstart.py` and start by constructing the data loaders.
+The helper `create_data_loaders` handles all ERA5 access mechanics.
+
+```python
+from weatherflow.data import create_data_loaders
+
+train_loader, val_loader = create_data_loaders(
+    variables=["z", "t"],
+    pressure_levels=[500],
+    train_slice=("2015", "2015"),
+    val_slice=("2016", "2016"),
+    batch_size=8,
+    num_workers=2,
+    normalize=True,
+)
+```
+
+> **Note:** When working offline, download the ERA5 subset manually and pass
+> `data_path="/path/to/local.zarr"` to load from disk instead of Google Cloud
+> Storage.
+
+## 2. Instantiate the model and optimiser
+
+```python
+import torch
+from weatherflow.models import WeatherFlowMatch
+
+model = WeatherFlowMatch(
+    input_channels=train_loader.dataset.shape[0],
+    hidden_dim=128,
+    n_layers=4,
+    use_attention=True,
+    physics_informed=True,
+)
+optimizer = torch.optim.Adam(model.parameters(), lr=1e-4, weight_decay=1e-5)
+```
+
+If you prefer a lighter network, replace `WeatherFlowMatch` with
+`PhysicsGuidedAttention` or `StochasticFlowModel`.
+
+## 3. Train with FlowTrainer
+
+```python
+import torch
+from weatherflow.training.flow_trainer import FlowTrainer
+
+device = "cuda" if torch.cuda.is_available() else "cpu"
+trainer = FlowTrainer(
+    model=model,
+    optimizer=optimizer,
+    device=device,
+    physics_regularization=True,
+    physics_lambda=0.1,
+)
+
+for epoch in range(5):
+    train_metrics = trainer.train_epoch(train_loader)
+    val_metrics = trainer.validate(val_loader)
+    print(
+        f"Epoch {epoch:02d} | "
+        f"train={train_metrics['loss']:.4f} "
+        f"val={val_metrics['val_loss']:.4f}"
+    )
+```
+
+Enable checkpointing by setting `checkpoint_dir="runs/quickstart"` when
+instantiating the trainer.
+
+## 4. Integrate a short forecast
+
+After training, generate a small trajectory using `WeatherFlowODE`:
+
+```python
+from weatherflow.models.flow_matching import WeatherFlowODE
+
+ode_model = WeatherFlowODE(model, solver_method="dopri5")
+
+with torch.no_grad():
+    batch = next(iter(val_loader))["input"].to(device)
+    times = torch.linspace(0.0, 1.0, steps=6, device=device)
+    trajectory = ode_model(batch, times)
+```
+
+Each entry in `trajectory` represents the predicted state at a given integration
+step.
+
+## 5. Visualise results
+
+Use `WeatherVisualizer` to inspect the final forecast versus the ground truth.
+
+```python
+from weatherflow.utils import WeatherVisualizer
+
+visualizer = WeatherVisualizer()
+visualizer.plot_comparison(
+    true_data={"z": batch[0, 0].cpu()},
+    pred_data={"z": trajectory[-1, 0, 0].cpu()},
+    var_name="z",
+    title="Geopotential Height – Forecast vs Truth",
+)
+```
+
+Call `visualizer.plot_field(...)` or `visualizer.create_prediction_animation(...)`
+to explore additional diagnostics. For flow evolution, try
+`weatherflow.utils.FlowVisualizer().visualize_flow(...)`.
+
+## 6. Optional: export metrics and checkpoints
+
+Add a small helper to persist results:
+
+```python
+import json
+from pathlib import Path
+
+output_dir = Path("runs/quickstart")
+output_dir.mkdir(parents=True, exist_ok=True)
+
+torch.save(model.state_dict(), output_dir / "model.pt")
+with open(output_dir / "metrics.json", "w") as fh:
+    json.dump({"train": train_metrics, "val": val_metrics}, fh, indent=2)
+```
+
+## 7. Validate your environment
+
+Run the unit tests to ensure everything functions as expected:
+
+```bash
+pytest
+```
+
+If you installed the documentation extras, you can also verify the docs build
+with `mkdocs build`.
+
+## 8. Next steps
+
+- Swap in more variables or multiple pressure levels by editing `variables` and
+  `pressure_levels`.
+- Enable the FastAPI dashboard described in [Advanced Usage](../advanced_usage.md)
+  for a guided, no-code exploration.
+- Continue with the [ERA5 tutorial](era5.md) to learn about derived variables and
+  dataset caching.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,19 +13,24 @@ theme:
     - search.highlight
 
 nav:
-  - Advanced Topics:
-    - Continuous Normalizing Flows: advanced_topics/continuous_normalizing_flows.md
-
   - Home: index.md
   - Installation: installation.md
+  - Getting Started: getting_started.md
   - Tutorials:
-    - Quick Start: tutorials/quickstart.md
-    - Working with ERA5: tutorials/era5.md
-    - Custom Physics: tutorials/physics.md
+      - Quick Start: tutorials/quickstart.md
+      - Working with ERA5: tutorials/era5.md
+      - Custom Physics Workflows: tutorials/physics.md
+  - Advanced Usage: advanced_usage.md
+  - Flow Matching Primer: flow_matching.md
+  - Advanced Topics:
+      - Continuous Normalizing Flows: advanced_topics/continuous_normalizing_flows.md
+      - Implementation Guide: advanced_topics/flow_matching_implementation.md
   - API Reference:
-    - Models: api/models.md
-    - Data Loading: api/data.md
-    - Visualization: api/visualization.md
+      - Data Loading: api/data.md
+      - Models: api/models.md
+      - Training: api/training.md
+      - Solvers and Paths: api/solvers.md
+      - Utilities and Visualization: api/visualization.md
   - Examples: examples.md
   - Release Notes: release_notes.md
 


### PR DESCRIPTION
## Summary
- rebuild the documentation navigation and landing page to describe the workflow and repository layout
- add detailed installation, getting started, advanced usage, and flow matching implementation guides
- expand tutorials, API reference pages, examples, and release notes, and link the README to the MkDocs site

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi' in the test environment)*
- `flake8` *(fails: command not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca08fae328832d8479150c3cdf5662