### PR TITLE
Add WeatherFlow usage evaluation report

### DIFF
--- a/docs/reports/weatherflow_usage_report.md
+++ b/docs/reports/weatherflow_usage_report.md
@@ -1,0 +1,66 @@
+# WeatherFlow Hands-on Evaluation Report
+
+## Environment and Setup
+- **Date:** 2025-09-17T01:29:09+00:00
+- **System:** GitHub Codespaces-style container with Python 3.12
+- **Repository commit:** 0ede41bcf01bfac6056693be766e6d731bd00238
+
+### Installation Attempts
+```bash
+pip install -e .
+```
+Result: failed because the build backend (`hatchling`) could not be downloaded through the proxy (HTTP 403). Networking restrictions prevent installing optional dependencies such as `fastapi` and the cartopy Natural Earth datasets.【d2ab8b†L1-L23】【801091†L1-L19】
+
+## Data Preparation
+Created a compact synthetic ERA5-like Zarr store (`test_env/data/era5_small.zarr`) with 6 timesteps, 2 pressure levels, and 16×8 longitude/latitude grids for variables geopotential, temperature, and wind components. This enables exercising loaders without external downloads.【1991c6†L1-L30】【3ded7f†L1-L2】
+
+Because the production `ERA5Dataset` attempts several remote access methods, I patched `gcsfs.GCSFileSystem` to raise immediately so the local Zarr fallback is used. With this change the loader succeeded and reported variable summaries, automatically computing derived wind-speed and vorticity fields.【c96ef9†L1-L19】
+
+```python
+import gcsfs
+class FailFS:
+    def __init__(self, *args, **kwargs):
+        raise RuntimeError('GCS not available')
+
+gcsfs.GCSFileSystem = FailFS
+```
+
+## Data Loading and Batching
+Using the patched dataset, I instantiated batches of geopotential/temperature pairs over a single pressure level. A custom `collate_fn` reshaped the `(variable, level, lat, lon)` tensors into channel-first maps to avoid datetime metadata collation errors.【1597b7†L1-L41】【a5c0db†L1-L2】
+
+```python
+from torch.utils.data import DataLoader
+
+def simple_collate(batch):
+    inputs = torch.stack([item['input'] for item in batch])
+    targets = torch.stack([item['target'] for item in batch])
+    metadatas = [item['metadata'] for item in batch]
+    return {'input': inputs, 'target': targets, 'metadata': metadatas}
+```
+
+## Core Modeling Workflows
+
+### Flow Matching Loss
+Configured `WeatherFlowMatch` (32 hidden units, 2 layers, no attention) and computed flow/physics losses on the synthetic batch. Divergence regularisation was active and returned separate diagnostics.【42af51†L1-L29】【77af56†L1-L4】
+
+### ODE-based Forecasting
+Wrapped the trained flow model with `WeatherFlowODE` (RK4 solver) and generated four-step trajectories; predictions returned the expected `[time, batch, channel, lat, lon]` tensor.【74057a†L1-L14】【dec35a†L1-L2】
+
+### Training Loop Abstractions
+Used `FlowTrainer` with the custom DataLoader, demonstrating progress logging, AMP disablement on CPU, and validation metrics aggregation. Training over three mini-batches finished in <0.2s on CPU.【f7ad05†L1-L35】【7ba677†L1-L5】
+
+## Visualisation Utilities
+With cartopy’s coastline downloads disabled (`coastlines=False`), `WeatherVisualizer.plot_field` successfully produced and saved a synthetic temperature map to `test_env/plots/field.png`.【2ade51†L1-L13】【2a36f2†L1-L2】
+
+## Probability Path Utilities
+Tested `GaussianProbPath` sampling, conditional score/vector-field evaluation, and both conversion helpers (`vector_field_to_score`, `score_to_vector_field`). Numerical differences remained below `1e-7`, validating the formulas against the synthetic schedules.【2e240f†L1-L24】【e1f91f†L1-L5】
+
+## Service Layer (FastAPI) Exploration
+Attempted to exercise the FastAPI dashboard API via `TestClient`, but the missing `fastapi` package (blocked installation) prevented further validation. Future work: vendor minimal dependencies or provide a requirements lockfile accessible inside restricted environments.【801091†L1-L19】
+
+## Key Takeaways and Recommendations
+1. **Offline friendliness:** The ERA5 loader can target local Zarr stores after bypassing cloud backends; documenting the patch strategy or providing a `prefer_local` flag would streamline this use case.
+2. **Batch metadata:** Default PyTorch collation fails on datetime metadata. Supplying a helper collate function (or returning dataclasses) would improve developer experience.
+3. **Visualization defaults:** Consider exposing a `coastlines` default parameter in `plot_comparison` to avoid cartopy downloads when offline.
+4. **API dependencies:** A lightweight extras group (e.g., `pip install weatherflow[api]`) or a vendored FastAPI copy would help in locked-down environments.
+5. **Demonstration assets:** The synthetic dataset plus training scripts used here could be packaged as quickstart assets for tutorials and tests.


### PR DESCRIPTION
## Summary
- document an end-to-end WeatherFlow user evaluation in `docs/reports/weatherflow_usage_report.md`
- capture data loading, model training/inference, visualization, and API findings with reproduction snippets and troubleshooting notes

## Testing
- pytest tests/test_models.py

------
https://chatgpt.com/codex/tasks/task_e_68ca0d3c642c832d9f5363369fbcd5c8