### PR TITLE
Add style-conditioned flow matching support

### DIFF
--- a/tests/test_style_transfer.py
+++ b/tests/test_style_transfer.py
@@ -1,0 +1,45 @@
+import numpy as np
+import torch
+from PIL import Image
+
+from weatherflow.data import StyleTransferDataset
+from weatherflow.models import StyleFlowMatch
+
+
+def test_style_transfer_dataset_accepts_multiple_modalities(tmp_path):
+    content_np = (np.ones((4, 4, 3)) * 127).astype(np.uint8)
+    target_tensor = torch.rand(3, 4, 4)
+
+    style_img = Image.fromarray(np.full((4, 4, 3), 255, dtype=np.uint8))
+    style_path = tmp_path / "style.png"
+    style_img.save(style_path)
+
+    dataset = StyleTransferDataset(
+        content_items=[content_np, target_tensor],
+        target_items=[target_tensor, content_np],
+        style_items=[style_path, style_img],
+    )
+
+    sample0 = dataset[0]
+    assert set(sample0.keys()) == {"input", "target", "style", "metadata"}
+    assert sample0["input"].shape == (3, 4, 4)
+    assert sample0["target"].shape == (3, 4, 4)
+    assert torch.isclose(sample0["style"].max(), torch.tensor(1.0))
+
+
+def test_style_flow_match_forward_supports_style_conditioning():
+    model = StyleFlowMatch(
+        input_channels=3,
+        style_channels=3,
+        hidden_dim=32,
+        n_layers=1,
+        use_attention=False,
+        physics_informed=False,
+    )
+
+    x = torch.randn(2, 3, 8, 8)
+    style = torch.randn(2, 3, 8, 8)
+    t = torch.rand(2)
+
+    output = model(x, t, style=style)
+    assert output.shape == x.shape

--- a/weatherflow/data/__init__.py
+++ b/weatherflow/data/__init__.py
@@ -1,4 +1,4 @@
 from .era5 import ERA5Dataset, create_data_loaders
-from .datasets import WeatherDataset  # Import WeatherDataset from datasets.py
+from .datasets import StyleTransferDataset, WeatherDataset
 
-__all__ = ['ERA5Dataset', 'WeatherDataset', 'create_data_loaders']
+__all__ = ['ERA5Dataset', 'WeatherDataset', 'StyleTransferDataset', 'create_data_loaders']

--- a/weatherflow/models/__init__.py
+++ b/weatherflow/models/__init__.py
@@ -1,11 +1,12 @@
 from .base import BaseWeatherModel
-from .flow_matching import WeatherFlowMatch, ConvNextBlock
+from .flow_matching import StyleFlowMatch, WeatherFlowMatch, ConvNextBlock
 from .physics_guided import PhysicsGuidedAttention
 from .stochastic import StochasticFlowModel
 
 __all__ = [
     'BaseWeatherModel',
     'WeatherFlowMatch',
+    'StyleFlowMatch',
     'PhysicsGuidedAttention',
     'StochasticFlowModel',
     'ConvNextBlock'


### PR DESCRIPTION
## Summary
- add a format-agnostic `StyleTransferDataset` for paired or unpaired style transfer inputs
- introduce a `StyleFlowMatch` model with style conditioning and integrate style batches into the trainer
- provide tests covering the new dataset conversions and style-conditioned forward pass

## Testing
- `pytest` *(fails: plotly layout error in `tests/education/test_graduate_tool.py::test_rossby_wave_lab_structure`; ERA5 dataset fetch blocked by network while running suite)*
- `pytest tests/test_style_transfer.py`
- `flake8` *(not run: installation blocked by proxy restrictions)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f376c0538832d9d87b58c6e220c66)