### PR TITLE
Fix Rossby wave lab axis layout

### DIFF
--- a/weatherflow/education/graduate_tool.py
+++ b/weatherflow/education/graduate_tool.py
@@ -323,10 +323,10 @@ class GraduateAtmosphericDynamicsTool:
                 yaxis_title="Meridional Wavenumber (m⁻¹)",
                 zaxis_title="Frequency (s⁻¹)",
             ),
+            xaxis_title="Zonal Wavenumber (m⁻¹)",
+            yaxis_title="Meridional Wavenumber (m⁻¹)",
             xaxis2_title="Zonal Wavenumber (m⁻¹)",
             yaxis2_title="Meridional Wavenumber (m⁻¹)",
-            xaxis3_title="Zonal Wavenumber (m⁻¹)",
-            yaxis3_title="Meridional Wavenumber (m⁻¹)",
             template="plotly_dark",
         )
         return fig


### PR DESCRIPTION
## Summary
- adjust Rossby wave lab layout to assign axis titles to existing subplots only
- prevent Plotly layout errors by removing references to non-existent third axes

## Testing
- pytest -q tests/education/test_graduate_tool.py::test_rossby_wave_lab_structure
- flake8 weatherflow/education/graduate_tool.py *(command not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f543106d8832dad320ac85254e9a2)