### PR TITLE
Fix Plotly export reference in visualization workbench

### DIFF
--- a/frontend/src/components/VisualizationWorkbench.tsx
+++ b/frontend/src/components/VisualizationWorkbench.tsx
@@ -335,11 +335,11 @@ function VisualizationWorkbench({ result }: Props): JSX.Element {
       layout={transectLayout}
       style={{ width: '100%', height: '100%' }}
       config={{ displayModeBar: false, responsive: true }}
-      onInitialized={(figure) => {
-        transectRef.current = figure as PlotlyHTMLElement;
+      onInitialized={(_, graphDiv) => {
+        transectRef.current = graphDiv;
       }}
-      onUpdate={(figure) => {
-        transectRef.current = figure as PlotlyHTMLElement;
+      onUpdate={(_, graphDiv) => {
+        transectRef.current = graphDiv;
       }}
     />
   );


### PR DESCRIPTION
## Summary
- capture the Plotly graphDiv from initialization and update callbacks so transect snapshot exports use the correct element

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695092d118d0832da9e22333d5da4752)