### PR TITLE
Gracefully skip torch-dependent tests and fix module docstrings

### DIFF
--- a/test_install.py
+++ b/test_install.py
@@ -1,6 +1,6 @@
-"""
-# test_install.py
-"""Lightweight install test for CI / local checks.
+"""test_install.py
+
+Lightweight install test for CI / local checks.
 
 This test verifies that the package imports and exposes version metadata without
 requiring heavy optional dependencies.

--- a/tests/test_data_era5.py
+++ b/tests/test_data_era5.py
@@ -1,9 +1,10 @@
 import json
 
 import numpy as np
-import torch
+import pytest
 import xarray as xr
 
+torch = pytest.importorskip("torch")
 from weatherflow.data.era5 import ERA5Dataset
 
 

--- a/tests/test_data_sequence.py
+++ b/tests/test_data_sequence.py
@@ -1,7 +1,8 @@
 import numpy as np
-import torch
+import pytest
 import xarray as xr
 
+torch = pytest.importorskip("torch")
 from weatherflow.data.sequence import MultiStepERA5Dataset
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,6 @@
-import torch
+import pytest
+
+torch = pytest.importorskip("torch")
 
 from weatherflow.models.flow_matching import WeatherFlowMatch, WeatherFlowODE
 

--- a/tests/test_physics_losses.py
+++ b/tests/test_physics_losses.py
@@ -1,8 +1,9 @@
 """Tests for enhanced physics-based loss functions."""
 
 import pytest
-import torch
 import numpy as np
+
+torch = pytest.importorskip("torch")
 from weatherflow.physics.losses import PhysicsLossCalculator
 
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,6 +1,7 @@
-import torch
-from torch.utils.data import DataLoader, TensorDataset
+import pytest
 
+torch = pytest.importorskip("torch")
+from torch.utils.data import DataLoader, TensorDataset
 from weatherflow.training.flow_trainer import FlowTrainer
 
 

--- a/weatherflow/__init__.py
+++ b/weatherflow/__init__.py
@@ -1,6 +1,6 @@
-"""
-# weatherflow/__init__.py
-"""WeatherFlow: A Deep Learning Library for Weather Prediction.
+"""weatherflow/__init__.py
+
+WeatherFlow: A Deep Learning Library for Weather Prediction.
 
 This module is intentionally lightweight on import. Heavy submodules and optional
 features are loaded lazily when accessed to avoid ImportError on simple imports

--- a/weatherflow/test_flow_trainer.py
+++ b/weatherflow/test_flow_trainer.py
@@ -1,10 +1,11 @@
-
-import torch
-import torch.nn as nn
 import numpy as np
 import os
 from pathlib import Path
+import pytest
+
+torch = pytest.importorskip("torch")
 from torch.utils.data import Dataset, DataLoader
+import torch.nn as nn
 
 # Import our improved modules
 from weatherflow.models.base import BaseWeatherModel


### PR DESCRIPTION
## Summary
- repair top-level docstrings in the package init and install smoke test to avoid unterminated strings
- guard torch-dependent tests with `pytest.importorskip` so environments without torch skip cleanly instead of failing collection
- apply the same optional-dependency handling to the FlowTrainer integration test module

## Testing
- pytest (torch-dependent suites skipped when torch is unavailable)
- flake8 (could not run; pip install blocked by network/proxy restrictions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695986d69dec832d99a08dfe1cfe3bcc)