### PR TITLE
Align flow training with rectified interpolation

### DIFF
--- a/docs/advanced_topics/flow_matching_implementation.md
+++ b/docs/advanced_topics/flow_matching_implementation.md
@@ -59,9 +59,12 @@ and supports multiple integration methods (Dopri5, RK4, midpoint).
 `FlowTrainer` stitches everything together:
 
 1. Samples \(t \sim \mathcal{U}(0, 1)\) for each batch element.
-2. Calls the model to evaluate the velocity field \(u_t(x)\).
-3. Computes the straight-line target velocity and the loss via
-   `compute_flow_loss` (with optional Huber/Smooth-L1 variants).
+2. Interpolates the current state \(x_t = (1 - t)x_0 + t x_1\) and evaluates the
+   velocity field \(u_t(x_t)\) there (instead of anchoring to \(x_0\)), which is
+   the standard rectified-flow practice.
+3. Compares the prediction to the constant displacement \(x_1 - x_0\) using
+   `compute_flow_loss` with optional Huber/Smooth-L1 variants and mid-trajectory
+   time weighting.
 4. Applies physics regularisation by delegating to
    `model.compute_physics_loss(...)` when available.
 5. Steps the optimiser with optional AMP scaling and scheduler updates.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -103,9 +103,11 @@ for epoch in range(2):
     print(f"Epoch {epoch}: {metrics['loss']:.4f} | val {val_metrics['val_loss']:.4f}")
 ```
 
-Behind the scenes, each iteration draws random interpolation times `t`, calls
-`model(x0, t)` to obtain the predicted velocity, and compares it against the
-straight-line target `(x1 - x0)/(1 - t)` computed by `compute_flow_loss`.
+Behind the scenes, each iteration draws random interpolation times `t`,
+constructs an interpolated state `x_t = torch.lerp(x0, x1, t.view(-1, 1, 1, 1))`,
+and feeds it to `model(x_t, t)`. The prediction is compared against the constant
+displacement `(x1 - x0)` via `compute_flow_loss`, optionally re-weighted toward
+the middle of the trajectory where the flow field carries the richest signal.
 
 > **Tip:** You can enable Weights & Biases logging by instantiating the trainer
 > with `use_wandb=True` after configuring your `wandb` credentials.

--- a/weatherflow/test_flow_trainer.py
+++ b/weatherflow/test_flow_trainer.py
@@ -145,7 +145,8 @@ def test_flow_trainer():
     batch = next(iter(train_loader))
     x0, x1 = batch
     t = torch.rand(x0.size(0))
-    v_t = model(x0, t)
+    x_t = torch.lerp(x0, x1, t.view(-1, 1, 1, 1))
+    v_t = model(x_t, t)
     
     # Test different loss types
     mse_loss = compute_flow_loss(v_t, x0, x1, t, loss_type='mse')


### PR DESCRIPTION
## Summary
- update the training loss to follow rectified-flow displacement targets with optional time weighting
- evaluate models on interpolated states during training/validation and align physics/metric calculations with velocity targets
- refresh flow-matching documentation and tests to reflect the rectified interpolation pathway

## Testing
- pytest -q *(fails: all tests skipped because PyTorch is unavailable and cannot be installed through the proxy)*
- flake8 weatherflow *(fails: flake8 could not be installed because outbound PyPI access is blocked by the proxy)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695988d81494832dafd1d447ad4a5e54)